### PR TITLE
Adding pkg-config to be installed as a build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo yum install -y alsa-lib-devel
 **Debian/Ubuntu**
 
 ```bash
-sudo apt install libasound2-dev
+sudo apt install libasound2-dev pkg-config
 ```
 
 ## Contribution


### PR DESCRIPTION
This fix the issue of missing build dependency (pkg-config)