### PR TITLE
Bevy 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,11 @@ categories = [ "game-engines" ]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-#bevy = { git = "https://github.com/bevyengine/bevy", rev = "47004dfcb415a049e4c6e68fdf56c26de72f51a1" }
-#bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
-bevy = { version = "0.5", default-features = false, features = [
+bevy = { version = "0.6.0", default-features = false, features = [
     #"bevy_audio"
     "bevy_dynamic_plugin",
     "bevy_gilrs",
     "bevy_gltf",
-    "bevy_wgpu",
     "bevy_winit",
     "render",
     "png",
@@ -26,13 +23,14 @@ bevy = { version = "0.5", default-features = false, features = [
     "mp3",
     "x11",
 ] }
-bevy_kira_audio = { version = "0.6.0", features = [
+bevy_kira_audio = { version = "0.8", features = [
     "flac",
     "mp3",
     "ogg",
     "wav",
 ] }
-bevy_prototype_debug_lines = "0.3"
+#bevy_prototype_debug_lines = "0.3"
+#bevy_prototype_debug_lines = { version = "0.4.0", path = "../bevy_debug_lines" }
 lazy_static = "1.4"
 log = "0.4"
 ron = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ bevy_kira_audio = { version = "0.8", features = [
 ] }
 #bevy_prototype_debug_lines = "0.3"
 #bevy_prototype_debug_lines = { version = "0.4.0", path = "../bevy_debug_lines" }
+bevy_prototype_debug_lines = { git = "https://github.com/Toqozz/bevy_debug_lines", branch = "bevy-main" }
 lazy_static = "1.4"
 log = "0.4"
 ron = "0.7"

--- a/examples/mouse_events.rs
+++ b/examples/mouse_events.rs
@@ -78,11 +78,11 @@ fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
         for mouse_motion in &engine_state.mouse_motion_events {
             cumulative_motion += mouse_motion.delta
         }
-        // There seems to be a Bevy 0.5 bug where every other frame we don't receive any mouse
+        // There seems to be a Bevy 0.6 bug where every other frame we don't receive any mouse
         // motion events, so ignore those frames.
         // TODO: Follow up on this bug in upstream Bevy
         if cumulative_motion != Vec2::ZERO {
-            sprite.translation = cumulative_motion + ORIGIN_LOCATION.into();
+            sprite.translation = cumulative_motion + Vec2::from(ORIGIN_LOCATION);
         }
     }
     true

--- a/examples/mouse_state.rs
+++ b/examples/mouse_state.rs
@@ -68,11 +68,11 @@ fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
     // mouse motion for the frame
     if let Some(sprite) = engine_state.sprites.get_mut("move indicator") {
         let motion = engine_state.mouse_state.motion();
-        // There seems to be a Bevy 0.5 bug where every other frame we don't receive any mouse
+        // There seems to be a Bevy 0.6 bug where every other frame we don't receive any mouse
         // motion events, so ignore those frames.
         // TODO: Follow up on this bug in upstream Bevy
         if motion != Vec2::ZERO {
-            sprite.translation = motion + ORIGIN_LOCATION.into();
+            sprite.translation = motion + Vec2::from(ORIGIN_LOCATION);
         }
     }
     true

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -28,12 +28,21 @@ fn main() {
     font_msg.font = "FiraMono-Medium.ttf".to_string();
     font_msg.translation.y = 0.0;
 
-    let msg = game.add_text("msg", "Changing the text's translation, rotation*, and scale* is fast,\n so feel free to do that a lot.");
+    let msg = game.add_text("msg", "Changing the text's translation, rotation, and scale is fast,\n so feel free to do that a lot.");
     msg.font_size = 24.0;
-    msg.translation.y = -150.0;
+    msg.translation.y = -100.0;
 
-    let msg2 = game.add_text("msg2", "*Changing rotation and scale will not work until Bevy 0.6 is released,\nbut changing the translation works great already!");
-    msg2.font_size = 20.0;
+    let translation = game.add_text("translation", "Translation");
+    translation.font_size = 36.0;
+    translation.translation = Vec2::new(-400.0, -230.0);
+
+    let rotation = game.add_text("rotation", "Rotation");
+    rotation.font_size = 36.0;
+    rotation.translation = Vec2::new(0.0, -230.0);
+
+    let scale = game.add_text("scale", "Scale");
+    scale.font_size = 36.0;
+    scale.translation = Vec2::new(400.0, -230.0);
 
     let game_state = GameState {
         timer: Timer::from_seconds(0.2, true),
@@ -48,9 +57,15 @@ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> boo
         fps.value = format!("FPS: {:.1}", 1.0 / engine_state.delta_f32);
     }
 
-    let msg2 = engine_state.texts.get_mut("msg2").unwrap();
-    msg2.translation.x = 50.0 * (engine_state.time_since_startup_f64 * 0.5).sin() as f32;
-    msg2.translation.y = 50.0 * (engine_state.time_since_startup_f64 * 0.5).cos() as f32 - 275.0;
+    let t = engine_state.texts.get_mut("translation").unwrap();
+    t.translation.x = 50.0 * (engine_state.time_since_startup_f64).sin() as f32 - 400.0;
+    t.translation.y = 50.0 * (engine_state.time_since_startup_f64).cos() as f32 - 230.0;
+
+    let r = engine_state.texts.get_mut("rotation").unwrap();
+    r.rotation -= 1.5 * engine_state.delta_f32;
+
+    let s = engine_state.texts.get_mut("scale").unwrap();
+    s.scale = 1.5 + ((engine_state.time_since_startup_f64 * 0.5).cos() as f32) * -1.0;
 
     let msg3 = engine_state.texts.get_mut("zoom_msg").unwrap();
     msg3.font_size = 10.0 * (engine_state.time_since_startup_f64 * 0.5).cos() as f32 + 25.0;

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -4,6 +4,7 @@ rusty_engine::init!();
 
 fn main() {
     let mut game = Game::new();
+
     game.window_settings(WindowDescriptor {
         width: 800.0,
         height: 200.0,

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -59,8 +59,8 @@ use std::array::IntoIter;
 pub struct AudioManagerPlugin;
 
 impl Plugin for AudioManagerPlugin {
-    fn build(&self, app: &mut bevy::prelude::AppBuilder) {
-        app.add_system(queue_managed_audio_system.system());
+    fn build(&self, app: &mut bevy::prelude::App) {
+        app.add_system(queue_managed_audio_system);
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,11 +1,10 @@
 use bevy::prelude::{
-    info, AssetServer, Assets, Color, ColorMaterial, Commands, HorizontalAlign, Query, Res, ResMut,
-    SpriteBundle, Text as BevyText, Text2dBundle, TextAlignment, TextStyle, Vec2, VerticalAlign,
-    Windows,
+    info, AssetServer, Color, Commands, HorizontalAlign, Res, ResMut, SpriteBundle,
+    Text as BevyText, Text2dBundle, TextAlignment, TextStyle, Vec2, VerticalAlign, Windows,
 };
 use bevy::utils::HashMap;
 pub use bevy::window::{WindowDescriptor, WindowMode, WindowResizeConstraints};
-use bevy_prototype_debug_lines::*;
+//use bevy_prototype_debug_lines::*;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -137,10 +136,9 @@ impl EngineState {
 pub fn setup(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    materials: ResMut<Assets<ColorMaterial>>,
     mut engine_state: ResMut<EngineState>,
 ) {
-    add_sprites(&mut commands, &asset_server, materials, &mut engine_state);
+    add_sprites(&mut commands, &asset_server, &mut engine_state);
     add_texts(&mut commands, &asset_server, &mut engine_state);
 }
 
@@ -149,14 +147,13 @@ pub fn setup(
 pub fn add_sprites(
     commands: &mut Commands,
     asset_server: &Res<AssetServer>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
     engine_state: &mut EngineState,
 ) {
     for (_, sprite) in engine_state.sprites.drain() {
         let transform = sprite.bevy_transform();
-        let texture_handle = asset_server.load(PathBuf::from("sprite").join(&sprite.filepath));
+        let texture_path = PathBuf::from("sprite").join(&sprite.filepath);
         commands.spawn().insert(sprite).insert_bundle(SpriteBundle {
-            material: materials.add(texture_handle.into()),
+            texture: asset_server.load(texture_path),
             transform,
             ..Default::default()
         });
@@ -207,6 +204,7 @@ pub fn update_window_dimensions(windows: Res<Windows>, mut engine_state: ResMut<
     }
 }
 
+/*
 // system - draw sprite colliders
 #[doc(hidden)]
 pub fn draw_sprite_colliders(
@@ -232,6 +230,7 @@ pub fn draw_sprite_colliders(
         }
     }
 }
+*/
 
 /// A [`Game`] represents the entire game and its data.
 /// By default the game will spawn an empty window, and exit upon Esc or closing of the window.
@@ -305,19 +304,19 @@ use rusty_engine::{
         AudioManagerPlugin, CollisionEvent, KeyboardInput, KeyboardPlugin, KeyboardState,
         MouseState, PhysicsPlugin,
     },
-    game::{draw_sprite_colliders, update_window_dimensions},
+    game::/*{draw_sprite_colliders, */update_window_dimensions/*}*/,
     sprite::{Sprite, SpritePreset},
     text::Text,
 };
 use bevy::{app::AppExit, input::system::exit_on_esc_system,
     prelude::{
-        App, AppBuilder, Assets, AssetServer, Color, ColorMaterial, Commands, DefaultPlugins,
+        App, Assets, AssetServer, Color, ColorMaterial, Commands, DefaultPlugins,
         Entity, EventReader, EventWriter, IntoSystem, OrthographicCameraBundle,
-        ParallelSystemDescriptorCoercion, Query, QuerySet, Res, ResMut, Text as BevyText, Transform,
-        Vec3,
+        ParallelSystemDescriptorCoercion, Query, QuerySet, QueryState, Res, ResMut,
+        Text as BevyText, Transform, Vec3,
     }, utils::HashMap};
 use bevy_kira_audio::*;
-use bevy_prototype_debug_lines::*;
+//use bevy_prototype_debug_lines::*;
 use std::{sync::Mutex, time::Duration, ops::{Deref, DerefMut}};
 
 
@@ -328,7 +327,7 @@ type LogicFunction = fn(&mut EngineState, &mut $game_state_type) -> bool;
 /// Under the hood, Rusty Engine syncs the game data to Bevy to power most of the underlying
 /// functionality.
 struct Game {
-    app_builder: AppBuilder,
+    app: App,
     engine_state: EngineState,
     logic_functions: Vec<LogicFunction>,
     window_descriptor: WindowDescriptor,
@@ -337,7 +336,7 @@ struct Game {
 impl Default for Game {
     fn default() -> Self {
         Self {
-            app_builder: App::build(),
+            app: App::new(),
             engine_state: EngineState::default(),
             logic_functions: vec![],
             window_descriptor: WindowDescriptor {
@@ -367,37 +366,36 @@ impl Game {
 
     /// documented in the public stub
     fn run(&mut self, initial_game_state: $game_state_type) {
-        self.app_builder
+        self.app
             .insert_resource::<WindowDescriptor>(self.window_descriptor.clone())
             .insert_resource::<$game_state_type>(initial_game_state);
-        self.app_builder
+        self.app
             // Built-ins
             .add_plugins_with(DefaultPlugins, |group| {
                 group.disable::<bevy::audio::AudioPlugin>()
             })
-            .add_system(exit_on_esc_system.system())
+            .add_system(exit_on_esc_system)
             // External Plugins
             .add_plugin(AudioPlugin) // kira_bevy_audio
-            .add_plugin(DebugLinesPlugin) // bevy_prototype_debug_lines, for debugging sprite colliders
+            //.add_plugin(DebugLinesPlugin) // bevy_prototype_debug_lines, for debugging sprite colliders
             // Rusty Engine Plugins
             .add_plugin(AudioManagerPlugin)
             .add_plugin(KeyboardPlugin)
             .add_plugin(MousePlugin)
             .add_plugin(PhysicsPlugin)
             //.insert_resource(ReportExecutionOrderAmbiguities) // for debugging
-            .add_system(update_window_dimensions.system().label("update_window_dimensions").before("game_logic_sync"))
-            .add_system(game_logic_sync.system().label("game_logic_sync"))
-            .add_system(draw_sprite_colliders.system().label("draw_sprite_colliders").after("game_logic_sync"))
-            .add_startup_system(rusty_engine::game::setup.system());
-        let world = self.app_builder.world_mut();
-        world
+            .add_system(update_window_dimensions.label("update_window_dimensions").before("game_logic_sync"))
+            .add_system(game_logic_sync.label("game_logic_sync"))
+            //.add_system(draw_sprite_colliders.label("draw_sprite_colliders").after("game_logic_sync"))
+            .add_startup_system(rusty_engine::game::setup);
+        self.app.world
             .spawn()
             .insert_bundle(OrthographicCameraBundle::new_2d());
         let engine_state = std::mem::take(&mut self.engine_state);
-        self.app_builder.insert_resource(engine_state);
+        self.app.insert_resource(engine_state);
         let logic_functions = std::mem::take(&mut self.logic_functions);
-        self.app_builder.insert_resource(logic_functions);
-        self.app_builder.run();
+        self.app.insert_resource(logic_functions);
+        self.app.run();
     }
 
     /// documented in the public stub
@@ -411,7 +409,6 @@ impl Game {
 fn game_logic_sync(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    materials: ResMut<Assets<ColorMaterial>>,
     mut engine_state: ResMut<EngineState>,
     mut game_state: ResMut<$game_state_type>,
     logic_functions: Res<Vec<LogicFunction>>,
@@ -421,10 +418,10 @@ fn game_logic_sync(
     mut app_exit_events: EventWriter<AppExit>,
     mut collision_events: EventReader<CollisionEvent>,
     mut query_set: QuerySet<(
-        Query<&Sprite>,
-        Query<&Text>,
-        Query<(Entity, &mut Sprite, &mut Transform)>,
-        Query<(Entity, &mut Text, &mut Transform, &mut BevyText)>,
+        QueryState<&Sprite>,
+        QueryState<&Text>,
+        QueryState<(Entity, &mut Sprite, &mut Transform)>,
+        QueryState<(Entity, &mut Text, &mut Transform, &mut BevyText)>,
     )>,
 ) {
     // Update this frame's timing info
@@ -479,7 +476,7 @@ fn game_logic_sync(
     }
 
     // Transfer any changes in the user's Sprite copies to the Bevy Sprite and Transform components
-    for (entity, mut sprite, mut transform) in query_set.q2_mut().iter_mut() {
+    for (entity, mut sprite, mut transform) in query_set.q2().iter_mut() {
         if let Some(sprite_copy) = engine_state.sprites.remove(&sprite.label) {
             *sprite = sprite_copy;
             *transform = sprite.bevy_transform();
@@ -489,7 +486,7 @@ fn game_logic_sync(
     }
 
     // Transfer any changes in the user's Texts to the Bevy Text and Transform components
-    for (entity, mut text, mut transform, mut bevy_text_component) in query_set.q3_mut().iter_mut() {
+    for (entity, mut text, mut transform, mut bevy_text_component) in query_set.q3().iter_mut() {
         if let Some(text_copy) = engine_state.texts.remove(&text.label) {
             *text = text_copy;
             *transform = text.bevy_transform();
@@ -511,7 +508,7 @@ fn game_logic_sync(
     }
 
     // Add Bevy components for any new sprites remaining in engine_state.sprites
-    rusty_engine::game::add_sprites(&mut commands, &asset_server, materials, &mut engine_state);
+    rusty_engine::game::add_sprites(&mut commands, &asset_server, &mut engine_state);
 
     // Add Bevy components for any new texts remaining in engine_state.texts
     rusty_engine::game::add_texts(&mut commands, &asset_server, &mut engine_state);

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,10 +1,10 @@
 use bevy::prelude::{
-    info, AssetServer, Color, Commands, HorizontalAlign, Res, ResMut, SpriteBundle,
+    info, AssetServer, Color, Commands, HorizontalAlign, Query, Res, ResMut, SpriteBundle,
     Text as BevyText, Text2dBundle, TextAlignment, TextStyle, Vec2, VerticalAlign, Windows,
 };
 use bevy::utils::HashMap;
 pub use bevy::window::{WindowDescriptor, WindowMode, WindowResizeConstraints};
-//use bevy_prototype_debug_lines::*;
+use bevy_prototype_debug_lines::*;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -204,7 +204,6 @@ pub fn update_window_dimensions(windows: Res<Windows>, mut engine_state: ResMut<
     }
 }
 
-/*
 // system - draw sprite colliders
 #[doc(hidden)]
 pub fn draw_sprite_colliders(
@@ -230,7 +229,6 @@ pub fn draw_sprite_colliders(
         }
     }
 }
-*/
 
 /// A [`Game`] represents the entire game and its data.
 /// By default the game will spawn an empty window, and exit upon Esc or closing of the window.
@@ -304,7 +302,7 @@ use rusty_engine::{
         AudioManagerPlugin, CollisionEvent, KeyboardInput, KeyboardPlugin, KeyboardState,
         MouseState, PhysicsPlugin,
     },
-    game::/*{draw_sprite_colliders, */update_window_dimensions/*}*/,
+    game::{draw_sprite_colliders, update_window_dimensions},
     sprite::{Sprite, SpritePreset},
     text::Text,
 };
@@ -316,7 +314,7 @@ use bevy::{app::AppExit, input::system::exit_on_esc_system,
         Text as BevyText, Transform, Vec3,
     }, utils::HashMap};
 use bevy_kira_audio::*;
-//use bevy_prototype_debug_lines::*;
+use bevy_prototype_debug_lines::*;
 use std::{sync::Mutex, time::Duration, ops::{Deref, DerefMut}};
 
 
@@ -377,7 +375,7 @@ impl Game {
             .add_system(exit_on_esc_system)
             // External Plugins
             .add_plugin(AudioPlugin) // kira_bevy_audio
-            //.add_plugin(DebugLinesPlugin) // bevy_prototype_debug_lines, for debugging sprite colliders
+            .add_plugin(DebugLinesPlugin::always_in_front()) // bevy_prototype_debug_lines, for displaying sprite colliders
             // Rusty Engine Plugins
             .add_plugin(AudioManagerPlugin)
             .add_plugin(KeyboardPlugin)
@@ -386,7 +384,7 @@ impl Game {
             //.insert_resource(ReportExecutionOrderAmbiguities) // for debugging
             .add_system(update_window_dimensions.label("update_window_dimensions").before("game_logic_sync"))
             .add_system(game_logic_sync.label("game_logic_sync"))
-            //.add_system(draw_sprite_colliders.label("draw_sprite_colliders").after("game_logic_sync"))
+            .add_system(draw_sprite_colliders.label("draw_sprite_colliders").after("game_logic_sync"))
             .add_startup_system(rusty_engine::game::setup);
         self.app.world
             .spawn()

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -7,10 +7,10 @@ pub use bevy::input::keyboard::{KeyCode, KeyboardInput};
 pub struct KeyboardPlugin;
 
 impl Plugin for KeyboardPlugin {
-    fn build(&self, app: &mut bevy::prelude::AppBuilder) {
+    fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource::<KeyboardState>(KeyboardState::default())
-            .add_system(sync_keyboard_events.system().before("game_logic_sync"))
-            .add_system(sync_keyboard_state.system().before("game_logic_sync"));
+            .add_system(sync_keyboard_events.before("game_logic_sync"))
+            .add_system(sync_keyboard_state.before("game_logic_sync"));
     }
 }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -13,10 +13,10 @@ pub use bevy::{
 pub struct MousePlugin;
 
 impl Plugin for MousePlugin {
-    fn build(&self, app: &mut bevy::prelude::AppBuilder) {
+    fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource(MouseState::default())
-            .add_system(sync_mouse_state.system().before("game_logic_sync"))
-            .add_system(sync_mouse_events.system().before("game_logic_sync"));
+            .add_system(sync_mouse_state.before("game_logic_sync"))
+            .add_system(sync_mouse_events.before("game_logic_sync"));
     }
 }
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -10,9 +10,9 @@ use std::{
 pub struct PhysicsPlugin;
 
 impl Plugin for PhysicsPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         app.add_event::<CollisionEvent>()
-            .add_system(collision_detection.system());
+            .add_system(collision_detection);
     }
 }
 

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 
 /// An [`Sprite`] is the basic abstraction for something that can be seen and interacted with.
 /// Players, obstacles, etc. are all sprites.
-#[derive(Clone, Debug)]
+#[derive(Clone, Component, Debug)]
 pub struct Sprite {
     /// READONLY: A way to identify a sprite.
     pub label: String,

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Quat, Transform, Vec2, Vec3};
+use bevy::prelude::{Component, Quat, Transform, Vec2, Vec3};
 
 /// Default depth of the text, positioned so it will be on top of other default layers. Depth
 /// can range from `0.0` (back) to `999.0` (front)
@@ -7,7 +7,7 @@ pub const TEXT_DEFAULT_LAYER: f32 = 900.0;
 pub const TEXT_DEFAULT_FONT_SIZE: f32 = 30.0;
 
 /// A [`Text`] is a bit of text that exists on the screen.
-#[derive(Clone, Debug)]
+#[derive(Clone, Component, Debug)]
 pub struct Text {
     /// READONLY: A label to identify the text. This is not the text that is displayed! This is the
     /// label you use to retrieve and modify your text from the


### PR DESCRIPTION
Looking good so far!

- Almost all of Rusty Engine works already
- Rotating and scaling text now works. YAY!!!
- `bevy_prototype_debug_lines` (for drawing the colliders) has not been updated for Bevy 0.6.0 yet, so it is currently commented out. [I made a PR out of my attempt to update it myself](https://github.com/Toqozz/bevy_debug_lines/pull/13), but I got lost in the rendering changes that don't seem to be discussed in either the news post or the upgrade guide.  If someone doesn't help out soon, I'll experiment with stretching a line sprite.

Changes affecting users of Rusty Engine:
- Use `Vec2::from(thething)` instead of `thething.into()` to convert a tuple of `(f32, f32)` to a `Vec2`. I've only ever seen this when you want a `const` of type `Vec2`--since `Vec2::new` isn't `const` you can use a `(f32, f32)` instead and convert to a `Vec2` at runtime.