### PR TITLE
Exclude assets and unneeded stuff from the package sent to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,16 @@ readme = "README.md"
 keywords = [ "game", "engine", "graphics", "audio", "rusty" ]
 categories = [ "game-engines" ]
 license = "MIT OR Apache-2.0"
+exclude = [
+    "/assets",
+    "/.github",
+    "/scenarios",
+    "/tutorial",
+    "/script",
+    "release.toml",
+    "RELEASE.md",
+    ".gitignore",
+]
 
 [dependencies]
 bevy = { version = "0.6.0", default-features = false, features = [


### PR DESCRIPTION
I should have done this ages ago when I bumped up against the limit of having too many assets in the package. I had hoped to find a way to get the assets to be readily available in the package so they didn't have to be downloaded separately, but it's a better design to keep them fully separate -- some folks may not want _any_ of the built-in assets now that we support loading your own arbitrary assets.

Now I can add as many assets to the asset pack as I want!