### PR TITLE
Switch to bevy_prototype_lyon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 
 ### BREAKING CHANGES
 
-- `Game` is now generic over the user-provided game state struct, so the `init!` macro from the short-lived `3.0.0` version has been removed!
+- `Game` is now generic over the user-provided game state struct, so the `init!` macro from the short-lived `3.0.0` version has been removed! All you need to do is delete the macro call if you have it.
+- `EngineState.debug_sprite_colliders` has been renamed `EngineState.show_colliders` for clarity.
 
 ### Other Changes
 
 - Upgraded to Bevy 0.6 in the back end
 - `Text` rotation and scale now works! 🎉
-- TODO: bevy_prototype_debug_lines hasn't had a release, and the `main` branch sorta works, but the lines now appear _under_ sprites instead of over them, which is not ideal. We _must_ have a release upstream and would _love_ a fix upstream. If there isn't an upstream release, we'll need to find another line-drawing solution before release.
+- Switched to `bevy_prototype_lyon` to power the debug lines. They look much nicer now that I can choose the line thickness.
 - Updated (or finished) all of the game scenario descriptions.
 
 ## [3.0.0] - 2021-12-30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,7 @@ bevy_kira_audio = { version = "0.8", features = [
     "ogg",
     "wav",
 ] }
-#bevy_prototype_debug_lines = "0.3"
-#bevy_prototype_debug_lines = { version = "0.4.0", path = "../bevy_debug_lines" }
-bevy_prototype_debug_lines = { git = "https://github.com/Toqozz/bevy_debug_lines", branch = "bevy-main" }
+bevy_prototype_lyon = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 ron = "0.7"

--- a/examples/collider_creator.rs
+++ b/examples/collider_creator.rs
@@ -48,7 +48,7 @@ fn main() {
 
     // Start with the "game" part
     let mut game = Game::new();
-    game.debug_sprite_colliders = true;
+    game.show_colliders = true;
     game.window_settings(WindowDescriptor {
         title: "Collider Creator".into(),
         ..Default::default()

--- a/examples/collision.rs
+++ b/examples/collision.rs
@@ -82,7 +82,7 @@ fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
 
     // Pressing C toggles sprite collider debug lines
     if engine_state.keyboard_state.just_pressed(KeyCode::C) {
-        engine_state.debug_sprite_colliders = !engine_state.debug_sprite_colliders;
+        engine_state.show_colliders = !engine_state.show_colliders;
     }
     true
 }

--- a/examples/scenarios/road_race.rs
+++ b/examples/scenarios/road_race.rs
@@ -15,6 +15,7 @@ struct GameState {
 
 fn main() {
     let mut game = Game::new();
+    game.show_colliders = true;
 
     // Create the player sprite
     let player1 = game.add_sprite("player1", RacingCarBlue);

--- a/src/game.rs
+++ b/src/game.rs
@@ -224,7 +224,7 @@ pub fn update_window_dimensions(windows: Res<Windows>, mut engine_state: ResMut<
 #[doc(hidden)]
 pub fn draw_sprite_colliders(
     engine_state: Res<EngineState>,
-    mut lines: ResMut<DebugLines>,
+    //mut lines: ResMut<DebugLines>,
     sprite_query: Query<&Sprite>,
 ) {
     if !engine_state.debug_sprite_colliders {
@@ -239,7 +239,7 @@ pub fn draw_sprite_colliders(
         let mut curr = 0;
         let mut next = 1;
         while curr < length {
-            lines.line(points[curr].extend(0.0), points[next].extend(0.0), 0.0);
+            //lines.line(points[curr].extend(0.0), points[next].extend(0.0), 0.0);
             curr += 1;
             next = (next + 1) % length;
         }
@@ -306,7 +306,7 @@ impl<S: Send + Sync + 'static> Game<S> {
             .add_system(exit_on_esc_system)
             // External Plugins
             .add_plugin(AudioPlugin) // kira_bevy_audio
-            .add_plugin(DebugLinesPlugin::always_in_front()) // bevy_prototype_debug_lines, for displaying sprite colliders
+            //.add_plugin(DebugLinesPlugin::always_in_front()) // bevy_prototype_debug_lines, for displaying sprite colliders
             // Rusty Engine Plugins
             .add_plugin(AudioManagerPlugin)
             .add_plugin(KeyboardPlugin)

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -282,6 +282,13 @@ impl Collider {
             .map(|&v| v * sprite.scale + sprite.translation) // scale & translation
             .collect()
     }
+    pub fn points(&self) -> Vec<Vec2> {
+        if let Self::Poly(points) = self {
+            points.clone()
+        } else {
+            Vec::with_capacity(0)
+        }
+    }
     pub fn colliding(sprite1: &Sprite, sprite2: &Sprite) -> bool {
         use Collider::*;
         if let NoCollider = sprite1.collider {


### PR DESCRIPTION
I thought there was a [problem with `bevy_prototype_debug_lines`](https://github.com/Toqozz/bevy_debug_lines/issues/14), but there wasn't. But I didn't know that, so I tried [switching to `bevy_prototype_lyon`](https://github.com/Nilirad/bevy_prototype_lyon/issues/140). It didn't fix the problem, because apparently [it's a Bevy 0.6 rendering problem](https://github.com/bevyengine/bevy/issues/3709).

But I liked the experience with `bevy_prototype_lyon` much better, so let's make that switch permanent.