### PR TITLE
Finish lyon-style collider lines

### DIFF
--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -121,6 +121,7 @@ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> boo
         || engine_state.keyboard_state.just_pressed(KeyCode::Back)
     {
         sprite.collider = Collider::NoCollider;
+        sprite.collider_dirty = true;
     }
     // Modify a collider point
     if engine_state.mouse_state.just_pressed(MouseButton::Left) {

--- a/examples/scenarios/road_race.rs
+++ b/examples/scenarios/road_race.rs
@@ -15,7 +15,6 @@ struct GameState {
 
 fn main() {
     let mut game = Game::new();
-    game.show_colliders = true;
 
     // Create the player sprite
     let player1 = game.add_sprite("player1", RacingCarBlue);

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -2,7 +2,7 @@ use bevy::prelude::{Component, Quat, Transform, Vec2, Vec3};
 
 use crate::physics::Collider;
 
-/// An [`Sprite`] is the basic abstraction for something that can be seen and interacted with.
+/// A [`Sprite`] is the basic abstraction for something that can be seen and interacted with.
 /// Players, obstacles, etc. are all sprites.
 #[derive(Clone, Component, Debug)]
 pub struct Sprite {
@@ -27,8 +27,10 @@ pub struct Sprite {
     pub collision: bool,
     /// Relative to translation
     pub collider: Collider,
-    // Used to detect when we need to create a new debug collider representation
-    pub(crate) collider_dirty: bool,
+    /// If set to `true`, then the collider shown for this sprite will be regenerated (see also
+    /// [`EngineState.show_colliders`](crate::prelude::EngineState)). This needs to be done if you
+    /// manually replace a `Sprite`'s [`Collider`] after the game has started.
+    pub collider_dirty: bool,
 }
 
 fn read_collider_from_file(filepath: &Path) -> Collider {
@@ -101,7 +103,7 @@ impl Sprite {
             return false;
         }
         // Bevy's asset system is relative from the assets/ subdirectory, so we must be too
-        let filepath = PathBuf::from("assets").join(self.collider_filepath.clone());
+        let filepath = PathBuf::from("assets/sprite").join(self.collider_filepath.clone());
         let mut fh = match File::create(filepath) {
             Ok(fh) => fh,
             Err(e) => {

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -27,9 +27,8 @@ pub struct Sprite {
     pub collision: bool,
     /// Relative to translation
     pub collider: Collider,
-    #[doc(hidden)]
-    // force people to use new()
-    phantom: PhantomData<()>,
+    // Used to detect when we need to create a new debug collider representation
+    pub(crate) collider_dirty: bool,
 }
 
 fn read_collider_from_file(filepath: &Path) -> Collider {
@@ -82,7 +81,7 @@ impl Sprite {
             scale: 1.0,
             collision: false,
             collider,
-            phantom: PhantomData,
+            collider_dirty: true,
         }
     }
 
@@ -129,6 +128,7 @@ impl Sprite {
     /// Add a collider point. `p` is a `Vec2` in worldspace (usually the mouse coordinate). See the
     /// `collider` example.
     pub fn add_collider_point(&mut self, mut p: Vec2) {
+        self.collider_dirty = true;
         // If there isn't a collider, we better switch to one
         if self.collider == Collider::NoCollider {
             self.collider = Collider::Poly(Vec::new());
@@ -151,6 +151,7 @@ impl Sprite {
     /// Change the last collider point. `p` is a `Vec2` in worldspace (usually the mouse
     /// coordinate). See the `collider` example.
     pub fn change_last_collider_point(&mut self, mut p: Vec2) {
+        self.collider_dirty = true;
         // If there isn't a collider, create one with a "last point" to change
         if self.collider == Collider::NoCollider {
             self.collider = Collider::Poly(vec![Vec2::ZERO]);
@@ -180,7 +181,6 @@ use std::{
     array::IntoIter,
     fs::File,
     io::Write,
-    marker::PhantomData,
     path::{Path, PathBuf},
 };
 


### PR DESCRIPTION
The initial implementation only created the collider lines for the sprites which existed at startup.

This implementation supports all the same features as before. I also optimized it a wee bit.