### PR TITLE
Logic functions no longer return bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### BREAKING CHANGES
+
+- Logic functions no longer return a `bool` to simplify the learning curve. If you want logic functions to run conditionally, instead track your state in your `GameState` and use it to exit early from your logic function.
+
 ## [4.0.0] - 2022-01-29
 
 ### BREAKING CHANGES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-bevy = { version = "0.6.0", default-features = false, features = [
+bevy = { version = "0.6.1", default-features = false, features = [
     #"bevy_audio"
     "bevy_dynamic_plugin",
     "bevy_gilrs",

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Write your game!
  // state struct (`&mut GameState` in this case). The function returns a `bool`.
  //
  // This function will be run once each frame.
- fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
      // The `EngineState` contains all sorts of built-in goodies.
      // Get access to the player sprite...
      let player = engine_state.sprites.get_mut("player").unwrap();
@@ -100,8 +100,6 @@ Write your game!
      if player.translation.x > 100.0 {
          game_state.health -= 1;
      }
-     // Returning `true` means the next logic function in line should be run.
-     true
  }
 
 ```

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -82,7 +82,7 @@ fn main() {
     game.run(Default::default());
 }
 
-fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     let sprite = engine_state.sprites.get_mut("sprite").unwrap();
     // Zoom levels
     if engine_state.keyboard_state.just_pressed(KeyCode::Key1) {
@@ -187,5 +187,4 @@ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> boo
             );
         }
     }
-    true
 }

--- a/examples/collision.rs
+++ b/examples/collision.rs
@@ -41,7 +41,7 @@ fn main() {
     game.run(());
 }
 
-fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
+fn logic(engine_state: &mut EngineState, _: &mut ()) {
     // If a collision event happened last frame, print it out and play a sound
     for collision_event in engine_state.collision_events.drain(..) {
         let text = engine_state.texts.get_mut("collision text").unwrap();
@@ -84,5 +84,4 @@ fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
     if engine_state.keyboard_state.just_pressed(KeyCode::C) {
         engine_state.show_colliders = !engine_state.show_colliders;
     }
-    true
 }

--- a/examples/game_state.rs
+++ b/examples/game_state.rs
@@ -28,7 +28,7 @@ fn main() {
     game.run(initial_game_state);
 }
 
-fn logic(engine_state: &mut EngineState, game_state: &mut MyCustomGameStateStuff) -> bool {
+fn logic(engine_state: &mut EngineState, game_state: &mut MyCustomGameStateStuff) {
     // Get mutable references to the variables in the game state that we care about
     let race_car = engine_state.sprites.get_mut("Race Car").unwrap();
 
@@ -52,5 +52,4 @@ fn logic(engine_state: &mut EngineState, game_state: &mut MyCustomGameStateStuff
             game_state.turning = false;
         }
     }
-    true
 }

--- a/examples/keyboard_events.rs
+++ b/examples/keyboard_events.rs
@@ -20,7 +20,7 @@ fn main() {
     game.run(());
 }
 
-fn logic(game_state: &mut EngineState, _: &mut ()) -> bool {
+fn logic(game_state: &mut EngineState, _: &mut ()) {
     // Get the race car sprite
     let race_car = game_state.sprites.get_mut("Race Car").unwrap();
 
@@ -55,5 +55,4 @@ fn logic(game_state: &mut EngineState, _: &mut ()) -> bool {
             );
         }
     }
-    true
 }

--- a/examples/keyboard_state.rs
+++ b/examples/keyboard_state.rs
@@ -22,7 +22,7 @@ fn main() {
     game.run(());
 }
 
-fn logic(game_state: &mut EngineState, _: &mut ()) -> bool {
+fn logic(game_state: &mut EngineState, _: &mut ()) {
     // Compute how fast we should move, rotate, and scale
     let move_amount = 200.0 * game_state.delta_f32;
     let rotation_amount = PI * game_state.delta_f32;
@@ -66,5 +66,4 @@ fn logic(game_state: &mut EngineState, _: &mut ()) -> bool {
         -game_state.window_dimensions * 0.5,
         game_state.window_dimensions * 0.5,
     );
-    true
 }

--- a/examples/level_creator.rs
+++ b/examples/level_creator.rs
@@ -66,7 +66,7 @@ Z - Print out Rust code of current level
     game.run(game_state);
 }
 
-fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     // Gather keyboard input
     let mut reset = false;
     let mut print_level = false;
@@ -137,7 +137,7 @@ fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
                 sprite.layer,
             );
         }
-        println!("\n    game.add_logic(logic);\n    game.run(GameState {{}});\n}}\n\nfn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {{\n    // Game Logic Goes Here\n    true\n}}")
+        println!("\n    game.add_logic(logic);\n    game.run(GameState {{}});\n}}\n\nfn logic(engine_state: &mut EngineState, game_state: &mut GameState) {{\n    // Game Logic Goes Here\n}}")
     }
 
     // Handle current sprite that has not yet been placed
@@ -250,5 +250,4 @@ fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
         game_state.next_sprite_num += 1;
         engine_state.sprites.insert(sprite.label.clone(), sprite);
     }
-    true
 }

--- a/examples/mouse_events.rs
+++ b/examples/mouse_events.rs
@@ -38,7 +38,7 @@ fn main() {
     game.run(());
 }
 
-fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
+fn logic(engine_state: &mut EngineState, _: &mut ()) {
     if let Some(sprite) = engine_state.sprites.get_mut("Race Car") {
         // Use mouse button events to rotate. Every click rotates the sprite by a fixed amount
         for mouse_button_input in &engine_state.mouse_button_events {
@@ -87,5 +87,4 @@ fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
             sprite.translation = cumulative_motion + Vec2::from(ORIGIN_LOCATION);
         }
     }
-    true
 }

--- a/examples/mouse_state.rs
+++ b/examples/mouse_state.rs
@@ -39,7 +39,7 @@ fn main() {
     game.run(());
 }
 
-fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
+fn logic(engine_state: &mut EngineState, _: &mut ()) {
     if let Some(sprite) = engine_state.sprites.get_mut("Race Car") {
         // Use the latest state of the mouse buttons to rotate the sprite
         let mut rotation_amount = 0.0;
@@ -77,5 +77,4 @@ fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
             sprite.translation = motion + Vec2::from(ORIGIN_LOCATION);
         }
     }
-    true
 }

--- a/examples/music_sampler.rs
+++ b/examples/music_sampler.rs
@@ -20,7 +20,7 @@ fn main() {
     game.run(GameState { music_index: 0 });
 }
 
-fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     let mut should_play_new_song = false;
     // Play a new song because a key was pressed
     for ev in engine_state.keyboard_events.drain(..) {
@@ -42,5 +42,4 @@ fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
         let note1 = engine_state.add_text("note1", format!("Looping: {:?}", music_preset));
         note1.font_size = 75.0;
     }
-    true
 }

--- a/examples/scenarios/car_shoot.rs
+++ b/examples/scenarios/car_shoot.rs
@@ -51,7 +51,7 @@ fn main() {
 const MARBLE_SPEED: f32 = 600.0;
 const CAR_SPEED: f32 = 300.0;
 
-fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     // Handle marble gun movement
     let player = engine_state.sprites.get_mut("player").unwrap();
     if let Some(location) = engine_state.mouse_state.location() {
@@ -159,6 +159,4 @@ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> boo
             .audio_manager
             .play_sfx(SfxPreset::Confirmation1, 0.5);
     }
-
-    true
 }

--- a/examples/scenarios/extreme_drivers_ed.rs
+++ b/examples/scenarios/extreme_drivers_ed.rs
@@ -834,7 +834,7 @@ fn main() {
 const TURN_RATE: f32 = 3.0;
 const ACCELERATION_RATE: f32 = 100.0;
 
-fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     let score_text = engine_state.texts.get_mut("score_text").unwrap();
 
     // if game_state.won {
@@ -845,11 +845,11 @@ fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
     //         //sprite.translation *= 1.0 + 1.5 * game_state.delta_f32;
     //         sprite.rotation += 1.0 * game_state.delta_f32;
     //     }
-    //     return true;
+    //     return;
     // }
 
     if game_state.crashed {
-        return true;
+        return;
     }
 
     // Player movement
@@ -894,7 +894,7 @@ fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
 
     // Don't do stuff past this point after we win
     if game_state.won {
-        return true;
+        return;
     }
 
     // Process collisions
@@ -941,5 +941,4 @@ fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
         you_win.font_size = 120.0;
         you_win.translation.y = -50.0;
     }
-    true
 }

--- a/examples/scenarios/road_race.rs
+++ b/examples/scenarios/road_race.rs
@@ -11,6 +11,7 @@ const PLAYER_SPEED: f32 = 250.0;
 
 struct GameState {
     health_amount: u8,
+    lost: bool,
 }
 
 fn main() {
@@ -57,19 +58,21 @@ fn main() {
     let health_message = game.add_text("health_message", "Health: 5");
     health_message.translation = Vec2::new(550.0, 320.0);
 
-    game.add_logic(lose_condition);
     game.add_logic(game_logic);
 
     // Run the game, which will run our game logic functions once every frame
-    game.run(GameState { health_amount: 5 });
+    game.run(GameState {
+        health_amount: 5,
+        lost: false,
+    });
 }
 
-fn lose_condition(_: &mut EngineState, game_state: &mut GameState) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     // Don't run any more game logic if the game has ended
-    game_state.health_amount > 0
-}
+    if game_state.lost {
+        return;
+    }
 
-fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
     // Respond to keyboard events and set the direction
     let mut direction = 0.0;
     if engine_state
@@ -124,11 +127,10 @@ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> boo
         }
     }
     if game_state.health_amount == 0 {
+        game_state.lost = true;
         let game_over = engine_state.add_text("game over", "Game Over");
         game_over.font_size = 128.0;
         engine_state.audio_manager.stop_music();
         engine_state.audio_manager.play_sfx(SfxPreset::Jingle3, 0.5);
     }
-
-    true
 }

--- a/examples/sfx_sampler.rs
+++ b/examples/sfx_sampler.rs
@@ -36,7 +36,7 @@ fn main() {
     game.run(game_state);
 }
 
-fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     for (i, timer) in game_state.sfx_timers.iter_mut().enumerate() {
         // None of the timers repeat, and they're all set to different times, so when the timer in
         // index X goes off, play sound effect in index X
@@ -59,5 +59,4 @@ fn logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
         let sfx_label = engine_state.texts.get_mut("sfx_label").unwrap();
         sfx_label.value = "That's all! Press Esc to quit.".into();
     }
-    true
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -53,7 +53,7 @@ fn main() {
     game.run(game_state);
 }
 
-fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     if game_state.timer.tick(engine_state.delta).just_finished() {
         let mut fps = engine_state.texts.get_mut("fps").unwrap();
         fps.value = format!("FPS: {:.1}", 1.0 / engine_state.delta_f32);
@@ -71,5 +71,4 @@ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> boo
 
     let msg3 = engine_state.texts.get_mut("zoom_msg").unwrap();
     msg3.font_size = 10.0 * (engine_state.time_since_startup_f64 * 0.5).cos() as f32 + 25.0;
-    true
 }

--- a/examples/transform.rs
+++ b/examples/transform.rs
@@ -26,7 +26,7 @@ fn main() {
     game.run(());
 }
 
-fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
+fn logic(engine_state: &mut EngineState, _: &mut ()) {
     let car1 = engine_state.sprites.get_mut("car1").unwrap();
     car1.translation.x = -300.0 + (engine_state.time_since_startup_f64.cos() * 100.0) as f32;
     car1.translation.y = (engine_state.time_since_startup_f64.sin() * 100.0) as f32;
@@ -36,5 +36,4 @@ fn logic(engine_state: &mut EngineState, _: &mut ()) -> bool {
 
     let car3 = engine_state.sprites.get_mut("car3").unwrap();
     car3.rotation = engine_state.time_since_startup_f64 as f32;
-    true
 }

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -26,9 +26,8 @@ fn main() {
     game.run(GameState {});
 }
 
-fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     // game logic goes here
-    true
 }
 ```
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -265,7 +265,7 @@ pub struct ColliderLines {
 pub struct Game<S: Send + Sync + 'static> {
     app: App,
     engine_state: EngineState,
-    logic_functions: Vec<fn(&mut EngineState, &mut S) -> bool>,
+    logic_functions: Vec<fn(&mut EngineState, &mut S)>,
     window_descriptor: WindowDescriptor,
 }
 
@@ -346,7 +346,7 @@ impl<S: Send + Sync + 'static> Game<S> {
     /// - `game_state`, which is a mutable reference (`&mut`) to the game state struct you defined, or `&mut ()` if you didn't define one.
     ///
     /// If `false` is returned, no more logic functions are processed this frame.
-    pub fn add_logic(&mut self, logic_function: fn(&mut EngineState, &mut S) -> bool) {
+    pub fn add_logic(&mut self, logic_function: fn(&mut EngineState, &mut S)) {
         self.logic_functions.push(logic_function);
     }
 }
@@ -358,7 +358,7 @@ fn game_logic_sync<S: Send + Sync + 'static>(
     asset_server: Res<AssetServer>,
     mut engine_state: ResMut<EngineState>,
     mut game_state: ResMut<S>,
-    logic_functions: Res<Vec<fn(&mut EngineState, &mut S) -> bool>>,
+    logic_functions: Res<Vec<fn(&mut EngineState, &mut S)>>,
     keyboard_state: Res<KeyboardState>,
     mouse_state: Res<MouseState>,
     time: Res<Time>,
@@ -415,10 +415,7 @@ fn game_logic_sync<S: Send + Sync + 'static>(
 
     // Perform all the user's game logic for this frame
     for func in logic_functions.iter() {
-        // If the user returns false, abort the rest of the game logic
-        if !func(&mut engine_state, &mut game_state) {
-            break;
-        }
+        func(&mut engine_state, &mut game_state);
     }
 
     if !engine_state.last_show_colliders && engine_state.show_colliders {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@
 //!
 //! // Your game logic functions can be named anything, but the first parameter is always a
 //! // `&mut EngineState`, and the second parameter is a mutable reference to your custom game
-//! // state struct (`&mut GameState` in this case). The function returns a `bool`.
+//! // state struct (`&mut GameState` in this case).
 //! //
 //! // This function will be run once each frame.
-//! fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+//! fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
 //!     // The `EngineState` contains all sorts of built-in goodies.
 //!     // Get access to the player sprite...
 //!     let player = engine_state.sprites.get_mut("player").unwrap();
@@ -48,8 +48,6 @@
 //!     if player.translation.x > 100.0 {
 //!         game_state.health -= 1;
 //!     }
-//!     // Returning `true` means the next logic function in line should be run.
-//!     true
 //! }
 //! ```
 //!

--- a/tutorial/src/02-quick-start.md
+++ b/tutorial/src/02-quick-start.md
@@ -43,7 +43,7 @@ curl -L https://github.com/CleanCut/rusty_engine/archive/refs/heads/main.tar.gz 
  // state struct (`&mut GameState` in this case). The function returns a `bool`.
  //
  // This function will be run once each frame.
- fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
      // The `EngineState` contains all sorts of built-in goodies.
      // Get access to the player sprite...
      let player = engine_state.sprites.get_mut("player").unwrap();
@@ -53,8 +53,6 @@ curl -L https://github.com/CleanCut/rusty_engine/archive/refs/heads/main.tar.gz 
      if player.translation.x > 100.0 {
          game_state.health -= 1;
      }
-     // Returning `true` means the next logic function in line should be run.
-     true
  }
  ```
 

--- a/tutorial/src/25-game-logic-function.md
+++ b/tutorial/src/25-game-logic-function.md
@@ -5,7 +5,7 @@ A game is divided up into _frames_. A _frame_ is one run through your game logic
 A game logic function definition looks like this:
 
 ```rust,ignore
-fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     // your actual game logic goes here
 }
 ```
@@ -13,7 +13,7 @@ fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> boo
 If you passed in a unit struct for your game state, then use a unit struct in your logic function definition:
 
 ```rust,ignore
-fn game_logic(engine_state: &mut EngineState, game_state: &mut ()) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut ()) {
     // logic...without any state to look at.
 }
 ```
@@ -32,18 +32,6 @@ You can add multiple game logic functions, which will always run in the order th
 game.add_logic(menu_logic);
 game.add_logic(game_logic);
 ```
-
-After each logic function is run, Rusty Engine checks the return value to see if it should continue with the next logic function. Game logic functions return a `bool`. If the return value is `true`, that means "keep on going!" and run the next logic function. If the return value is `false`, then Rusty Engine skips the rest of the logic functions this frame. If you don't want your game logic to run while you are in a menu, then your make sure your menu logic runs first and returns `false` if you are in the menu, then the rest of the logic functions won't run that frame.
-
-Most of the time you want the next function to run, so most game logic functions end like this:
-
-```rust,ignore
-    // ...
-    true
-}
-```
-
-The return value of the last game logic function in the chain is ignored.
 
 ## Example
 
@@ -71,9 +59,8 @@ fn main() {
     game.run(game_state);
 }
 
-fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) -> bool {
+fn game_logic(engine_state: &mut EngineState, game_state: &mut GameState) {
     game_state.current_score += 1;
     println!("Current score: {}", game_state.current_score);
-    true
 }
 ```


### PR DESCRIPTION
I'm removing the `bool` return type of logic functions to simplify things. I never use it my courses. To my knowledge, none of my students use it.

To achieve the same effect, store some state in your GameState and return early from logic functions that you don't want to run while in that state.