### PR TITLE
Fix collider example utility not re-rendering the collider lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- The `collider` example once again properly regenerates the visualization for circle colliders whenever they are created or altered.
+
 ## [5.0.0] - 2022-03-12
 
 ### BREAKING CHANGES

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -158,6 +158,7 @@ fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
         KeyCode::C,
     ]) {
         sprite.collider = Collider::circle(game_state.circle_radius);
+        sprite.collider_dirty = true;
     }
     // Let the user know whether or not their collider is currently convex
     let convex = engine.texts.get_mut("convex").unwrap();


### PR DESCRIPTION
Fix collider example utility not re-rendering the collider lines when a circle collider is generated or resized.