### PR TITLE
Sprite loading improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### New
+
+- The `collider` example can be installed globally with `cargo install rusty_engine --example collider` and run in the root of your own project with `collider assets/some-image.png`.
+
+### Fixed
+
+- The `collider` example can now load sprites from anywhere inside `assets/`, instead of only from inside `assets/sprite/`.
+
 ## [5.0.1] - 2022-04-11
 
 ### Improved

--- a/src/game.rs
+++ b/src/game.rs
@@ -187,7 +187,7 @@ pub fn add_sprites(commands: &mut Commands, asset_server: &Res<AssetServer>, eng
     for (_, sprite) in engine.sprites.drain() {
         // Create the sprite
         let transform = sprite.bevy_transform();
-        let texture_path = PathBuf::from("sprite").join(&sprite.filepath);
+        let texture_path = sprite.filepath.clone();
         commands.spawn().insert(sprite).insert_bundle(SpriteBundle {
             texture: asset_server.load(texture_path),
             transform,

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -63,7 +63,7 @@ impl Sprite {
         let filepath = file_or_preset.into();
         let mut collider_filepath = filepath.clone();
         collider_filepath.set_extension("collider");
-        let actual_collider_filepath = PathBuf::from("assets/sprite").join(&collider_filepath);
+        let actual_collider_filepath = PathBuf::from("assets").join(&collider_filepath);
         let collider = if actual_collider_filepath.exists() {
             read_collider_from_file(actual_collider_filepath.as_path())
         } else {
@@ -103,7 +103,7 @@ impl Sprite {
             return false;
         }
         // Bevy's asset system is relative from the assets/ subdirectory, so we must be too
-        let filepath = PathBuf::from("assets/sprite").join(self.collider_filepath.clone());
+        let filepath = PathBuf::from("assets").join(self.collider_filepath.clone());
         let mut fh = match File::create(filepath) {
             Ok(fh) => fh,
             Err(e) => {

--- a/tutorial/src/10-assets.md
+++ b/tutorial/src/10-assets.md
@@ -27,10 +27,9 @@ assets
     └── rolling
 ```
 
-All audio files should be stored in `assets/audio`*. The asset pack divides sounds into `music` and `sfx` subdirectories.
+You can organize your own custom files wherever you like, but the asset pack will always be organized like this:
 
-All font files should be stored in `assets/font`*.
+- Audio files in `assets/audio`. The asset pack divides sounds into `music` and `sfx` subdirectories.
+- Font files in `assets/font`.
+- Sprites (images and colliders) in `assets/sprite`.
 
-All sprites should be stored in `assets/sprite`*.
-
-*Additional subdirectories may be used for organization inside of these directories, as the asset pack does in some cases.

--- a/tutorial/src/65-sprite-collider.md
+++ b/tutorial/src/65-sprite-collider.md
@@ -34,14 +34,14 @@ All of the sprite presets in the game already have colliders, so you only have t
 
 If you create a new sprite using your own image, and you want it to produce `CollisionEvent`s, then you need to create a collider for that sprite.
 
-Creating colliders from scratch is quite tedius, so there is an "example" program called `collider` that you can use to create a collider! To run `collider`, clone the [`rusty_engine`](https://github.com/CleanCut/rusty_engine/) repository, place your image file in the `assets/sprite` directory (let's call it `db.png`), and then run:
+Creating colliders from scratch is quite tedius, so there is an "example" program called `collider` that you can use to create a collider! To run `collider`, clone the [`rusty_engine`](https://github.com/CleanCut/rusty_engine/) repository, place your image file in the `assets` directory (let's call it `db.png`), and then run:
 
 ```text
-$ cargo run --release --example collider assets/sprite/db.png
+$ cargo run --release --example collider assets/db.png
 ```
 
 Then follow the directions to create (or re-create) a collider and write it to a file.
 
 <img width="1392" alt="Screen Shot 2021-12-26 at 10 45 40 PM" src="https://user-images.githubusercontent.com/5838512/147438683-c8af2db7-66dd-463c-a269-d03f37869496.png">
 
-Once you have a good collider created, copy (or move) both your image and `.collider` file to your own project, under the `assets/sprite` directory.
+Once you have a good collider created, copy (or move) both your image and `.collider` files to your own project, under the `assets/` directory somewhere, and then [add the sprite to your game](55-sprite-creation.md)


### PR DESCRIPTION
- Load sprites from anywhere in `assets/`
- Make collider example work when installed with `cargo install rusty_engine --example collider`