### PR TITLE
Function either_contains renamed to either_equals_to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Improved
 
+- Fixed `CollisionPair::either_contains` to use `.contains` instead of `==`, contributed by [@etnt](https://github.com/etnt) in [#51](https://github.com/CleanCut/rusty_engine/pull/51)
+- Added `CollisionPair::either_equals_to` which uses `==`, contributed by [@etnt](https://github.com/etnt) in [#51](https://github.com/CleanCut/rusty_engine/pull/51)
 - Fixed documentation for a few fields of the `Engine` struct which were in the wrong place.
 
 ## [5.0.6] - 2022-05-19

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -64,6 +64,11 @@ impl CollisionPair {
     /// Whether either of the labels contains the text.
     pub fn either_contains<T: Into<String>>(&self, text: T) -> bool {
         let text = text.into();
+        self.0.contains(&text) || self.1.contains(&text)
+    }
+    /// Whether either of the labels equals to the text.
+    pub fn either_equals_to<T: Into<String>>(&self, text: T) -> bool {
+        let text = text.into();
         (self.0 == text) || (self.1 == text)
     }
     /// Whether either of the labels starts with the text.


### PR DESCRIPTION
The old function either_contains perfomed an equal test
which was a bit confusing. It is now renamed to better
reflect its functionality.

A new function named either_contains is introduced which
actually invokes the str::contains function.