### PR TITLE
feat(collider): allow tab completion for files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cargo/config.toml
 .vscode
+.idea
 **/*.rs.bk
 **/target
 Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Improved
 
 - The `collider` (example) editor now snaps to half-pixels.
+- The `collider` (example) editor now handles relative paths that begin with `./` or `.\`, which was especially vexing to powershell users. Contributed by [@webbertakken](https://github.com/webbertakken) in [#59].
+
+[#59]: https://github.com/CleanCut/rusty_engine/pull/59
 
 ## [5.2.0] - 2022-09-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ bevy = { version = "0.8.1", default-features = false, features = [
 bevy_prototype_lyon = "0.6"
 ron = "0.7"
 serde = { version = "1.0", features = [ "derive" ] }
-regex = "1.7"
 
 [dev-dependencies]
 rand = "0.8"
+regex = "1.7"
 
 [[example]]
 name = "car_shoot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ serde = { version = "1.0", features = [ "derive" ] }
 
 [dev-dependencies]
 rand = "0.8"
-regex = "1.7"
 
 [[example]]
 name = "car_shoot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ bevy = { version = "0.8.1", default-features = false, features = [
 bevy_prototype_lyon = "0.6"
 ron = "0.7"
 serde = { version = "1.0", features = [ "derive" ] }
+regex = "1.7"
 
 [dev-dependencies]
 rand = "0.8"

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -32,7 +32,7 @@ impl Default for GameState {
 }
 
 // If the user passed in `./assets/something...` then we need to strip `./assets/` (the asset loader will prepend `assets/`)
-const REDUNDANT_PATH_SEGMENTS: &str = r"^(.[/\\]+)?assets[/\\]+";
+const REDUNDANT_PATH_SEGMENTS: &str = r"^(\.[/\\]+)?assets[/\\]+";
 
 fn main() {
     // Some trickiness to make assets load relative to the current working directory, which
@@ -247,6 +247,31 @@ mod test {
             (".\\assets\\sprite\\sprite.png", "sprite\\sprite.png"),
             ("./assets\\sprite\\sprite.png", "sprite\\sprite.png"),
             (".\\assets/sprite/sprite.png", "sprite/sprite.png"),
+        ];
+
+        let replacer = Regex::new(REDUNDANT_PATH_SEGMENTS).unwrap();
+        // Loop through paths
+        for (input, expected) in paths {
+            // Replace the redundant path segments
+            let output = replacer.replace_all(input, "").to_string();
+            // Make sure the result matches the expected path
+            assert_eq!(output, expected);
+        }
+    }
+
+    #[test]
+    fn dont_strip_lookalikes() {
+        // Map of relative paths to their expected stripped paths
+        let paths = vec![
+            (
+                "assets-lookalike/sprite/sprite.png",
+                "assets-lookalike/sprite/sprite.png",
+            ),
+            (
+                "b/assets\\sprite\\sprite.png",
+                "b/assets\\sprite\\sprite.png",
+            ),
+            ("b\\assets/sprite/sprite.png", "b\\assets/sprite/sprite.png"),
         ];
 
         let replacer = Regex::new(REDUNDANT_PATH_SEGMENTS).unwrap();

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -32,7 +32,7 @@ impl Default for GameState {
 }
 
 // If the user passed in `./assets/something...` then we need to strip `./assets/` (the asset loader will prepend `assets/`)
-const REDUNDANT_PATH_SEGMENTS: &str = r"^[.\\/]*(assets)?[/\\]+";
+const REDUNDANT_PATH_SEGMENTS: &str = r"^(.[/\\]+)?assets[/\\]+";
 
 fn main() {
     // Some trickiness to make assets load relative to the current working directory, which
@@ -221,8 +221,10 @@ mod test {
     fn redundant_path_segments_dont_match_absolute_paths() {
         // Map of absolute paths that should not be touched by the regex
         let paths = vec![
-            "C:\\Users\\User\\Documents\\Game\\assets\\sprite\\sprite.png",
             "C:/Users/User/Documents/Game/assets/sprite/sprite.png",
+            "C:\\Users\\User\\Documents\\Game\\assets\\sprite\\sprite.png",
+            "/assets/sprite/sprite.png",
+            "\\assets\\sprite\\sprite.png",
         ];
 
         let replacer = Regex::new(REDUNDANT_PATH_SEGMENTS).unwrap();

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -32,7 +32,7 @@ impl Default for GameState {
 }
 
 // If the user passed in `./assets/something...` then we need to strip `./assets/` (the asset loader will prepend `assets/`)
-const REDUNDANT_PATH_SEGMENTS: &str = r"^(\.[/\\]+)?assets[/\\]+";
+const REDUNDANT_PATH_SEGMENTS: &str = r"^(\.[/\\]{1})?assets[/\\]+";
 
 fn main() {
     // Some trickiness to make assets load relative to the current working directory, which

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -12,6 +12,7 @@
 //!
 //! cargo run --release --example collider assets/some_image.png
 
+use regex::Regex;
 use std::path::PathBuf;
 
 use rusty_engine::prelude::*;
@@ -29,6 +30,9 @@ impl Default for GameState {
         }
     }
 }
+
+// If the user passed in `./assets/something...` then we need to strip `./assets/` (the asset loader will prepend `assets/`)
+const REDUNDANT_PATH_SEGMENTS: &str = r"^[.\\/]*(assets)?[/\\]+";
 
 fn main() {
     // Some trickiness to make assets load relative to the current working directory, which
@@ -51,11 +55,12 @@ fn main() {
         std::process::exit(1);
     }
 
-    // If the user passed in `assets/something...` then we need to strip `assets/` (the asset loader will prepend `assets/`)
-    let mut path = PathBuf::from(args[0].clone());
-    if path.starts_with("assets") {
-        path = path.strip_prefix("assets").unwrap().to_path_buf();
-    }
+    // Remove redundant path segments
+    let replacer = Regex::new(REDUNDANT_PATH_SEGMENTS).unwrap();
+    let path = replacer.replace_all(args[0].as_str(), "").to_string();
+
+    // Make sure that the file exists
+    let path = PathBuf::from(path);
     if !(PathBuf::from("assets").join(&path)).exists() {
         println!("Couldn't find the file {}", path.to_string_lossy());
         std::process::exit(1);
@@ -204,6 +209,51 @@ fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
                 "Error: unable to write the collider file: {}",
                 sprite.collider_filepath.to_string_lossy()
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn redundant_path_segments_dont_match_absolute_paths() {
+        // Map of absolute paths that should not be touched by the regex
+        let paths = vec![
+            "C:\\Users\\User\\Documents\\Game\\assets\\sprite\\sprite.png",
+            "C:/Users/User/Documents/Game/assets/sprite/sprite.png",
+        ];
+
+        let replacer = Regex::new(REDUNDANT_PATH_SEGMENTS).unwrap();
+        // Loop through paths
+        for input in paths {
+            // Replace the redundant path segments
+            let output = replacer.replace_all(input, "").to_string();
+            // Make sure the path is not changed
+            assert_eq!(output, input);
+        }
+    }
+
+    #[test]
+    fn redundant_path_segments_match_cross_platform_paths() {
+        // Map of relative paths to their expected stripped paths
+        let paths = vec![
+            ("assets/sprite/sprite.png", "sprite/sprite.png"),
+            ("assets\\sprite\\sprite.png", "sprite\\sprite.png"),
+            ("./assets/sprite/sprite.png", "sprite/sprite.png"),
+            (".\\assets\\sprite\\sprite.png", "sprite\\sprite.png"),
+            ("./assets\\sprite\\sprite.png", "sprite\\sprite.png"),
+            (".\\assets/sprite/sprite.png", "sprite/sprite.png"),
+        ];
+
+        let replacer = Regex::new(REDUNDANT_PATH_SEGMENTS).unwrap();
+        // Loop through paths
+        for (input, expected) in paths {
+            // Replace the redundant path segments
+            let output = replacer.replace_all(input, "").to_string();
+            // Make sure the result matches the expected path
+            assert_eq!(output, expected);
         }
     }
 }


### PR DESCRIPTION
## Changes

- Allows usage cross platform syntax that results from auto-completing paths to asset files.
- Added tests for the regex to ensure it doesn't break for anyone.

For example, in powershell an autocomplete always adds the `.\` regardless of whether you typed it or not.

```powershell
collider .\assets\textures\arenas\church_ctf_1\container-1.png
```
resulting in
```console
Couldn't find the file .\assets\textures\arenas\church_ctf_1\container-1.png
```

Tests:

![image](https://user-images.githubusercontent.com/20756439/201450602-8d033f8c-c4e5-4d10-86da-5dd613603f79.png)
