### PR TITLE
Upgrade to Bevy 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Breaking changes
+
+- `WindowDescriptor` has been renamed to `Window`
+- You must new add `#[derive(Resource)]` above your `GameState` struct.
+- It is no longer possible to use the unit type `()` instead of a `GameState` struct. Always create a `GameState` struct (it can be an empty struct with no fields).
+- The `Timer` now takes a `TimerMode` enum variant instead of a `bool`. Use `TimerMode::Once` for a timer that runs once, or `TimerMode::Repeating` for a repeating timer.
+
+### Improved
+
+- Update bevy from 0.8 to 0.10
+- Update bevy_prototype_lyon from 0.6 to 0.8
+- Update ron from 0.7 to 0.8
+- Fixed some inconsistent parameter names in examples
+
+
 ## [5.2.1] - 2022-11-15
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@
   - `LShift` -> `ShiftLeft`
   - `LWin` -> `SuperLeft`
   - `RWin` -> `SuperRight`
-  
+
 
 ### Improved
 
-- Update bevy from 0.8 to 0.11
-- Update bevy_prototype_lyon from 0.6 to 0.9
+- Update bevy from 0.8 to 0.12
+- Update bevy_prototype_lyon from 0.6 to 0.10
 - Update ron from 0.7 to 0.8
 - Fixed some inconsistent parameter names in examples
 - Some examples' audio was turned down lower

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,27 @@
 - You must new add `#[derive(Resource)]` above your `GameState` struct.
 - It is no longer possible to use the unit type `()` instead of a `GameState` struct. Always create a `GameState` struct (it can be an empty struct with no fields).
 - The `Timer` now takes a `TimerMode` enum variant instead of a `bool`. Use `TimerMode::Once` for a timer that runs once, or `TimerMode::Repeating` for a repeating timer.
+- The following `KeyCode` variants have been renamed:
+  - `LShift` -> `ShiftLeft`
+  - `RShift` -> `ShiftRight`
+  - `LAlt` -> `AltLeft`
+  - `RAlt` -> `AltRight`
+  - `LBracket` -> `BracketLeft`
+  - `RBracket` -> `BracketRight`
+  - `LControl` -> `ControlLeft`
+  - `RControl` -> `ControlRight`
+  - `LShift` -> `ShiftLeft`
+  - `LWin` -> `SuperLeft`
+  - `RWin` -> `SuperRight`
+  
 
 ### Improved
 
-- Update bevy from 0.8 to 0.10
-- Update bevy_prototype_lyon from 0.6 to 0.8
+- Update bevy from 0.8 to 0.11
+- Update bevy_prototype_lyon from 0.6 to 0.9
 - Update ron from 0.7 to 0.8
 - Fixed some inconsistent parameter names in examples
+- Some examples' audio was turned down lower
 
 
 ## [5.2.1] - 2022-11-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-bevy = { version = "0.11.3", default-features = false, features = [
+bevy = { version = "0.12.1", default-features = false, features = [
     "bevy_audio",
     "bevy_gilrs",
     "bevy_gltf",
@@ -34,7 +34,7 @@ bevy = { version = "0.11.3", default-features = false, features = [
     "x11",
     "vorbis",
 ] }
-bevy_prototype_lyon = "0.9.0"
+bevy_prototype_lyon = "0.10.0"
 ron = "0.8"
 serde = { version = "1.0", features = [ "derive" ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,19 +21,20 @@ exclude = [
 ]
 
 [dependencies]
-bevy = { version = "0.9.1", default-features = false, features = [
+bevy = { version = "0.10.1", default-features = false, features = [
     "bevy_audio",
     "bevy_gilrs",
     "bevy_gltf",
+    "bevy_render",
+    "bevy_text",
     "bevy_winit",
-    "render",
     "png",
     "hdr",
     "mp3",
     "x11",
     "vorbis",
 ] }
-bevy_prototype_lyon = "0.7"
+bevy_prototype_lyon = "0.8"
 ron = "0.8"
 serde = { version = "1.0", features = [ "derive" ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-bevy = { version = "0.10.1", default-features = false, features = [
+bevy = { version = "0.11.3", default-features = false, features = [
     "bevy_audio",
     "bevy_gilrs",
     "bevy_gltf",
@@ -34,7 +34,7 @@ bevy = { version = "0.10.1", default-features = false, features = [
     "x11",
     "vorbis",
 ] }
-bevy_prototype_lyon = "0.8"
+bevy_prototype_lyon = "0.9.0"
 ron = "0.8"
 serde = { version = "1.0", features = [ "derive" ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-bevy = { version = "0.8.1", default-features = false, features = [
+bevy = { version = "0.9.1", default-features = false, features = [
     "bevy_audio",
     "bevy_gilrs",
     "bevy_gltf",
@@ -33,8 +33,8 @@ bevy = { version = "0.8.1", default-features = false, features = [
     "x11",
     "vorbis",
 ] }
-bevy_prototype_lyon = "0.6"
-ron = "0.7"
+bevy_prototype_lyon = "0.7"
+ron = "0.8"
 serde = { version = "1.0", features = [ "derive" ] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Write your game!
  use rusty_engine::prelude::*;
 
  // Define a struct to hold custom data for your game (it can be a lot more complicated than this one!)
+ #[derive(Resource)]
  struct GameState {
      health: i32,
  }
@@ -78,7 +79,7 @@ Write your game!
      // Set up your game. `Game` exposes all of the methods and fields of `Engine`.
      let sprite = game.add_sprite("player", SpritePreset::RacingCarBlue);
      sprite.scale = 2.0;
-     game.audio_manager.play_music(MusicPreset::Classy8Bit, 1.0);
+     game.audio_manager.play_music(MusicPreset::Classy8Bit, 0.1);
      // Add one or more functions with logic for your game. When the game is run, the logic
      // functions will run in the order they were added.
      game.add_logic(game_logic);

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,8 +16,11 @@ Configuration goes in `release.toml`
 # First, choose `major`, `minor`, or `patch` for the level to release
 
 # Next, run the command in dry-run mode
-$ cargo release -vv LEVEL
+$ cargo release -v LEVEL
 
 # Then do it for real with the same level
 $ cargo release --execute LEVEL
+
+# Then publish an updated tutorial
+$ script/publish_tutorial
 ```

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -154,7 +154,7 @@ fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
             let location = (((location / game_state.scale) * 2.0).round() * 0.5) * game_state.scale;
             if engine
                 .keyboard_state
-                .pressed_any(&[KeyCode::RShift, KeyCode::LShift])
+                .pressed_any(&[KeyCode::ShiftLeft, KeyCode::ShiftRight])
             {
                 sprite.change_last_collider_point(location);
             } else {

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -71,7 +71,7 @@ fn main() {
     // Start with the "game" part
     let mut game = Game::new();
     game.show_colliders = true;
-    game.window_settings(WindowDescriptor {
+    game.window_settings(Window {
         title: "Collider Creator".into(),
         ..Default::default()
     });

--- a/examples/collider.rs
+++ b/examples/collider.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     circle_radius: f32,
     scale: f32,

--- a/examples/collision.rs
+++ b/examples/collision.rs
@@ -6,6 +6,9 @@ use rusty_engine::prelude::*;
 
 const ROTATION_SPEED: f32 = 3.0;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
     let msg2 = game.add_text(
@@ -15,7 +18,7 @@ fn main() {
     msg2.font_size = 20.0;
     msg2.translation.y = 340.0;
 
-    let mut race_car = game.add_sprite("Player", SpritePreset::RacingCarGreen);
+    let race_car = game.add_sprite("Player", SpritePreset::RacingCarGreen);
     race_car.translation = Vec2::new(0.0, 0.0);
     race_car.rotation = UP;
     race_car.layer = 100.0;
@@ -28,20 +31,20 @@ fn main() {
                 break 'outer;
             }
             let sprite_preset = sprite_presets_iter.next().unwrap();
-            let mut sprite = game.add_sprite(format!("{:?}", sprite_preset), sprite_preset);
+            let sprite = game.add_sprite(format!("{:?}", sprite_preset), sprite_preset);
             sprite.translation = Vec2::new(x as f32, (-y) as f32);
             sprite.collision = true;
         }
     }
 
-    let mut text = game.add_text("collision text", "");
+    let text = game.add_text("collision text", "");
     text.translation = Vec2::new(0.0, -200.0);
 
     game.add_logic(logic);
-    game.run(());
+    game.run(GameState {});
 }
 
-fn logic(engine: &mut Engine, _: &mut ()) {
+fn logic(engine: &mut Engine, _: &mut GameState) {
     // If a collision event happened last frame, print it out and play a sound
     for collision_event in engine.collision_events.drain(..) {
         let text = engine.texts.get_mut("collision text").unwrap();

--- a/examples/game_state.rs
+++ b/examples/game_state.rs
@@ -8,6 +8,7 @@ use rusty_engine::prelude::*;
 
 // You can name your game state struct whatever you want, and it can contain many different types as
 // its fields
+#[derive(Resource)]
 struct MyCustomGameStateStuff {
     // Use a timer to tell when to start/stop turning
     change_timer: Timer,
@@ -20,7 +21,7 @@ fn main() {
     let _ = game.add_sprite("Race Car", SpritePreset::RacingCarGreen);
 
     let initial_game_state = MyCustomGameStateStuff {
-        change_timer: Timer::from_seconds(1.0, true),
+        change_timer: Timer::from_seconds(1.0, TimerMode::Repeating),
         turning: false,
     };
 

--- a/examples/keyboard_events.rs
+++ b/examples/keyboard_events.rs
@@ -4,10 +4,13 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
-    let mut race_car = game.add_sprite("Race Car", SpritePreset::RacingCarGreen);
+    let race_car = game.add_sprite("Race Car", SpritePreset::RacingCarGreen);
     race_car.translation = Vec2::new(0.0, 0.0);
     race_car.rotation = UP;
     race_car.scale = 1.0;
@@ -17,15 +20,15 @@ fn main() {
     text.translation.y = 250.0;
 
     game.add_logic(logic);
-    game.run(());
+    game.run(GameState {});
 }
 
-fn logic(game_state: &mut Engine, _: &mut ()) {
+fn logic(engine: &mut Engine, _: &mut GameState) {
     // Get the race car sprite
-    let race_car = game_state.sprites.get_mut("Race Car").unwrap();
+    let race_car = engine.sprites.get_mut("Race Car").unwrap();
 
     // Loop through any keyboard input that hasn't been processed this frame
-    for keyboard_event in &game_state.keyboard_events {
+    for keyboard_event in &engine.keyboard_events {
         if let KeyboardInput {
             scan_code: _,
             key_code: Some(key_code),
@@ -50,8 +53,8 @@ fn logic(game_state: &mut Engine, _: &mut ()) {
 
             // Clamp the translation so that the car stays on the screen
             race_car.translation = race_car.translation.clamp(
-                -game_state.window_dimensions * 0.5,
-                game_state.window_dimensions * 0.5,
+                -engine.window_dimensions * 0.5,
+                engine.window_dimensions * 0.5,
             );
         }
     }

--- a/examples/keyboard_events.rs
+++ b/examples/keyboard_events.rs
@@ -33,6 +33,7 @@ fn logic(engine: &mut Engine, _: &mut GameState) {
             scan_code: _,
             key_code: Some(key_code),
             state: ButtonState::Pressed,
+            window: _,
         } = keyboard_event
         {
             // Handle various keypresses. The extra keys are for the Dvorak keyboard layout. ;-)

--- a/examples/keyboard_state.rs
+++ b/examples/keyboard_state.rs
@@ -6,10 +6,13 @@ use std::f32::consts::PI;
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
-    let mut race_car = game.add_sprite("Race Car", SpritePreset::RacingCarGreen);
+    let race_car = game.add_sprite("Race Car", SpritePreset::RacingCarGreen);
     race_car.translation = Vec2::new(0.0, 0.0);
     race_car.rotation = UP;
     race_car.scale = 1.0;
@@ -19,20 +22,20 @@ fn main() {
     text.translation.y = 250.0;
 
     game.add_logic(logic);
-    game.run(());
+    game.run(GameState {});
 }
 
-fn logic(game_state: &mut Engine, _: &mut ()) {
+fn logic(engine: &mut Engine, _: &mut GameState) {
     // Compute how fast we should move, rotate, and scale
-    let move_amount = 200.0 * game_state.delta_f32;
-    let rotation_amount = PI * game_state.delta_f32;
-    let scale_amount = 1.0 * game_state.delta_f32;
+    let move_amount = 200.0 * engine.delta_f32;
+    let rotation_amount = PI * engine.delta_f32;
+    let scale_amount = 1.0 * engine.delta_f32;
 
     // Get the race car sprite
-    let race_car = game_state.sprites.get_mut("Race Car").unwrap();
+    let race_car = engine.sprites.get_mut("Race Car").unwrap();
 
     // Handle keyboard input
-    let ks = &mut game_state.keyboard_state;
+    let ks = &mut engine.keyboard_state;
     if ks.pressed_any(&[KeyCode::W, KeyCode::Up, KeyCode::Comma]) {
         race_car.translation.y += move_amount;
     }
@@ -67,7 +70,7 @@ fn logic(game_state: &mut Engine, _: &mut ()) {
 
     // Clamp the translation so that the car stays on the screen
     race_car.translation = race_car.translation.clamp(
-        -game_state.window_dimensions * 0.5,
-        game_state.window_dimensions * 0.5,
+        -engine.window_dimensions * 0.5,
+        engine.window_dimensions * 0.5,
     );
 }

--- a/examples/layer.rs
+++ b/examples/layer.rs
@@ -4,18 +4,21 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
     let mut layer = 0.0;
     let preset_iterator = SpritePreset::variant_iter().peekable();
     for (x, sprite_preset) in (-300..=600).step_by(30).zip(preset_iterator) {
-        let mut sprite = game.add_sprite(format!("{:?}", sprite_preset), sprite_preset);
+        let sprite = game.add_sprite(format!("{:?}", sprite_preset), sprite_preset);
         sprite.translation = Vec2::new(x as f32, (-x) as f32);
         sprite.layer = layer; // 0.0 is the bottom (back) layer. 999.0 is the top (front) layer.
         layer += 1.0;
     }
 
     // We don't do anything after game setup, so our game logic can be an empty closure
-    game.run(());
+    game.run(GameState {});
 }

--- a/examples/level_creator.rs
+++ b/examples/level_creator.rs
@@ -99,6 +99,7 @@ fn logic(engine: &mut Engine, game_state: &mut GameState) {
             scan_code: _,
             key_code: Some(key_code),
             state,
+            window: _,
         } = keyboard_event
         {
             if *state == ButtonState::Pressed {
@@ -106,7 +107,7 @@ fn logic(engine: &mut Engine, game_state: &mut GameState) {
                     KeyCode::Z | KeyCode::Semicolon => {
                         print_level = true;
                     }
-                    KeyCode::LShift | KeyCode::RShift => {
+                    KeyCode::ShiftLeft | KeyCode::ShiftRight => {
                         game_state.shift_pressed = true;
                     }
                     KeyCode::R | KeyCode::P => {
@@ -128,7 +129,7 @@ fn logic(engine: &mut Engine, game_state: &mut GameState) {
                 }
             } else {
                 match key_code {
-                    KeyCode::LShift | KeyCode::RShift => {
+                    KeyCode::ShiftLeft | KeyCode::ShiftRight => {
                         game_state.shift_pressed = false;
                     }
                     _ => {}
@@ -140,7 +141,7 @@ fn logic(engine: &mut Engine, game_state: &mut GameState) {
     // Print out the level?
     if print_level {
         println!(
-            "---------------\n\nuse rusty_engine::prelude::*;\n\nstruct GameState {{}}\n\nfn main() {{\n    let mut game = Game::new();\n"
+            "---------------\n\nuse rusty_engine::prelude::*;\n\n#[derive(Resource)]\nstruct GameState {{}}\n\nfn main() {{\n    let mut game = Game::new();\n"
         );
         for sprite in engine.sprites.values() {
             if sprite.label == game_state.current_label {

--- a/examples/level_creator.rs
+++ b/examples/level_creator.rs
@@ -12,6 +12,7 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     current_label: String,
     // Use an incrementing index (converted to a string) for the unique label of the sprites
@@ -77,7 +78,7 @@ Z - Print out Rust code of current level
     let game_state = GameState::default();
 
     // Get our first sprite onto the board
-    let mut curr_sprite = game.add_sprite("0".to_string(), SpritePreset::RacingCarRed);
+    let curr_sprite = game.add_sprite("0".to_string(), SpritePreset::RacingCarRed);
     //curr_sprite.scale = 0.5;
     curr_sprite.layer = MAX_LAYER;
 

--- a/examples/mouse_events.rs
+++ b/examples/mouse_events.rs
@@ -6,6 +6,9 @@ use rusty_engine::prelude::*;
 
 const ORIGIN_LOCATION: (f32, f32) = (0.0, -200.0);
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
@@ -35,10 +38,10 @@ fn main() {
     msg2.translation.y = 275.0;
 
     game.add_logic(logic);
-    game.run(());
+    game.run(GameState {});
 }
 
-fn logic(engine: &mut Engine, _: &mut ()) {
+fn logic(engine: &mut Engine, _: &mut GameState) {
     if let Some(sprite) = engine.sprites.get_mut("Race Car") {
         // Use mouse button events to rotate. Every click rotates the sprite by a fixed amount
         for mouse_button_input in &engine.mouse_button_events {

--- a/examples/mouse_state.rs
+++ b/examples/mouse_state.rs
@@ -13,7 +13,7 @@ struct GameState {}
 fn main() {
     let mut game = Game::new();
 
-    let race_car = game.add_sprite("Race Car", SpritePreset::RacingCarGreen);
+    let race_car = game.add_sprite("Race Car", "sprite/racing/car_blue.png");
     race_car.translation = Vec2::new(0.0, 0.0);
     race_car.rotation = UP;
     race_car.scale = 1.0;

--- a/examples/mouse_state.rs
+++ b/examples/mouse_state.rs
@@ -7,6 +7,9 @@ use rusty_engine::prelude::*;
 const ORIGIN_LOCATION: (f32, f32) = (0.0, -200.0);
 const ROTATION_SPEED: f32 = 3.0;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
@@ -36,10 +39,10 @@ fn main() {
     msg2.translation.y = 275.0;
 
     game.add_logic(logic);
-    game.run(());
+    game.run(GameState {});
 }
 
-fn logic(engine: &mut Engine, _: &mut ()) {
+fn logic(engine: &mut Engine, _: &mut GameState) {
     if let Some(sprite) = engine.sprites.get_mut("Race Car") {
         // Use the latest state of the mouse buttons to rotate the sprite
         let mut rotation_amount = 0.0;

--- a/examples/music.rs
+++ b/examples/music.rs
@@ -7,6 +7,9 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
     let msg = game.add_text(
@@ -24,5 +27,5 @@ fn main() {
 
     game.audio_manager.play_music(MusicPreset::Classy8Bit, 1.0);
 
-    game.run(());
+    game.run(GameState {});
 }

--- a/examples/music_sampler.rs
+++ b/examples/music_sampler.rs
@@ -4,6 +4,7 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     music_index: usize,
 }

--- a/examples/placement.rs
+++ b/examples/placement.rs
@@ -10,17 +10,17 @@ struct GameState {}
 fn main() {
     let mut game = Game::new();
 
-    let mut car1 = game.add_sprite("car1", SpritePreset::RacingCarRed);
+    let car1 = game.add_sprite("car1", SpritePreset::RacingCarRed);
     car1.translation = Vec2::new(-300.0, 0.0);
     car1.rotation = UP;
     car1.scale = 1.0;
 
-    let mut car2 = game.add_sprite("car2", SpritePreset::RacingCarGreen);
+    let car2 = game.add_sprite("car2", SpritePreset::RacingCarGreen);
     car2.translation = Vec2::new(0.0, 0.0);
     car2.rotation = UP;
     car2.scale = 1.0;
 
-    let mut car3 = game.add_sprite("car3", SpritePreset::RacingCarBlue);
+    let car3 = game.add_sprite("car3", SpritePreset::RacingCarBlue);
     car3.translation = Vec2::new(300.0, 0.0);
     car3.rotation = UP;
     car3.scale = 1.0;

--- a/examples/placement.rs
+++ b/examples/placement.rs
@@ -4,6 +4,9 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
@@ -23,10 +26,10 @@ fn main() {
     car3.scale = 1.0;
 
     game.add_logic(logic);
-    game.run(());
+    game.run(GameState {});
 }
 
-fn logic(engine: &mut Engine, _: &mut ()) {
+fn logic(engine: &mut Engine, _: &mut GameState) {
     let car1 = engine.sprites.get_mut("car1").unwrap();
     car1.translation.x = -300.0 + (engine.time_since_startup_f64.cos() * 100.0) as f32;
     car1.translation.y = (engine.time_since_startup_f64.sin() * 100.0) as f32;

--- a/examples/scenarios/car_shoot.rs
+++ b/examples/scenarios/car_shoot.rs
@@ -5,6 +5,7 @@
 use rand::prelude::*;
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     marble_labels: Vec<String>,
     cars_left: i32,
@@ -18,7 +19,7 @@ fn main() {
     let game_state = GameState {
         marble_labels: vec!["marble1".into(), "marble2".into(), "marble3".into()],
         cars_left: 25,
-        spawn_timer: Timer::from_seconds(0.0, false),
+        spawn_timer: Timer::from_seconds(0.0, TimerMode::Once),
     };
 
     // Set the title of the window
@@ -97,7 +98,8 @@ fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
     // Spawn cars
     if game_state.spawn_timer.tick(engine.delta).just_finished() {
         // Reset the timer to a new value
-        game_state.spawn_timer = Timer::from_seconds(thread_rng().gen_range(0.1..1.25), false);
+        game_state.spawn_timer =
+            Timer::from_seconds(thread_rng().gen_range(0.1..1.25), TimerMode::Once);
         // Get the new car
         if game_state.cars_left > 0 {
             game_state.cars_left -= 1;

--- a/examples/scenarios/car_shoot.rs
+++ b/examples/scenarios/car_shoot.rs
@@ -23,7 +23,7 @@ fn main() {
     };
 
     // Set the title of the window
-    game.window_settings(WindowDescriptor {
+    game.window_settings(Window {
         title: "Car Shoot".into(),
         ..Default::default()
     });

--- a/examples/scenarios/extreme_drivers_ed.rs
+++ b/examples/scenarios/extreme_drivers_ed.rs
@@ -806,7 +806,7 @@ fn main() {
     a.collision = true;
 
     // Music!
-    game.audio_manager.play_music(MusicPreset::Classy8Bit, 0.5);
+    game.audio_manager.play_music(MusicPreset::Classy8Bit, 0.1);
 
     // Stuff used to keep and display score
     let score_text = game.add_text("score_text", "Score: 0");
@@ -916,7 +916,7 @@ fn logic(engine: &mut Engine, game_state: &mut GameState) {
                 event.pair.1.clone()
             };
             engine.sprites.remove(&shiny_label);
-            engine.audio_manager.play_sfx(SfxPreset::Confirmation1, 1.0);
+            engine.audio_manager.play_sfx(SfxPreset::Confirmation1, 0.5);
             game_state.score += 1;
             score_text.value = format!("Score: {}", game_state.score);
             if game_state.score >= game_state.win_amount {
@@ -928,14 +928,14 @@ fn logic(engine: &mut Engine, game_state: &mut GameState) {
         // Crash!
         game_state.crashed = true;
         //game_state.add_text("crashed", "You crashed. You fail. :-(");
-        engine.audio_manager.play_sfx(SfxPreset::Jingle3, 1.0);
+        engine.audio_manager.play_sfx(SfxPreset::Jingle3, 0.5);
         engine.audio_manager.stop_music();
     }
 
     if game_state.won {
         engine
             .audio_manager
-            .play_sfx(SfxPreset::Congratulations, 1.0);
+            .play_sfx(SfxPreset::Congratulations, 0.5);
         let you_win = engine.add_text("you win", "You Win!");
         you_win.font_size = 120.0;
         you_win.translation.y = -50.0;

--- a/examples/scenarios/extreme_drivers_ed.rs
+++ b/examples/scenarios/extreme_drivers_ed.rs
@@ -4,6 +4,7 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     score: u32,
     win_amount: u32,
@@ -935,7 +936,7 @@ fn logic(engine: &mut Engine, game_state: &mut GameState) {
         engine
             .audio_manager
             .play_sfx(SfxPreset::Congratulations, 1.0);
-        let mut you_win = engine.add_text("you win", "You Win!");
+        let you_win = engine.add_text("you win", "You Win!");
         you_win.font_size = 120.0;
         you_win.translation.y = -50.0;
     }

--- a/examples/scenarios/road_race.rs
+++ b/examples/scenarios/road_race.rs
@@ -8,6 +8,7 @@ use rusty_engine::prelude::*;
 const PLAYER_SPEED: f32 = 250.0;
 const ROAD_SPEED: f32 = 400.0;
 
+#[derive(Resource)]
 struct GameState {
     health_amount: u8,
     lost: bool,

--- a/examples/sfx.rs
+++ b/examples/sfx.rs
@@ -7,6 +7,9 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
     let msg = game.add_text(
@@ -24,5 +27,5 @@ fn main() {
 
     game.audio_manager.play_sfx(SfxPreset::Jingle1, 1.0);
 
-    game.run(());
+    game.run(GameState {});
 }

--- a/examples/sfx_sampler.rs
+++ b/examples/sfx_sampler.rs
@@ -4,7 +4,7 @@
 
 use rusty_engine::prelude::*;
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 struct GameState {
     sfx_timers: Vec<Timer>,
     end_timer: Timer,
@@ -18,17 +18,19 @@ fn main() {
     for (i, _sfx) in SfxPreset::variant_iter().enumerate() {
         game_state
             .sfx_timers
-            .push(Timer::from_seconds((i as f32) * 2.0, false));
+            .push(Timer::from_seconds((i as f32) * 2.0, TimerMode::Once));
     }
     // One timer to end them all
-    game_state.end_timer =
-        Timer::from_seconds((SfxPreset::variant_iter().len() as f32) * 2.0 + 1.0, false);
+    game_state.end_timer = Timer::from_seconds(
+        (SfxPreset::variant_iter().len() as f32) * 2.0 + 1.0,
+        TimerMode::Once,
+    );
 
-    let mut msg = game.add_text("msg", "Playing sound effects!");
+    let msg = game.add_text("msg", "Playing sound effects!");
     msg.translation = Vec2::new(0.0, 100.0);
     msg.font_size = 60.0;
 
-    let mut sfx_label = game.add_text("sfx_label", "");
+    let sfx_label = game.add_text("sfx_label", "");
     sfx_label.translation = Vec2::new(0.0, -100.0);
     sfx_label.font_size = 90.0;
 

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -7,6 +7,9 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
     let msg = game.add_text(
@@ -24,5 +27,5 @@ fn main() {
 
     game.audio_manager.play_sfx("sfx/congratulations.ogg", 1.0);
 
-    game.run(());
+    game.run(GameState {});
 }

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -4,6 +4,9 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
@@ -15,14 +18,14 @@ fn main() {
             }
             let sprite_preset = sprite_presets_iter.next().unwrap();
             let sprite_string = format!("{:?}", sprite_preset);
-            let mut sprite = game.add_sprite(&sprite_string, sprite_preset);
+            let sprite = game.add_sprite(&sprite_string, sprite_preset);
             sprite.translation = Vec2::new(x as f32, (-y) as f32);
 
-            let mut text = game.add_text(&sprite_string, &sprite_string);
+            let text = game.add_text(&sprite_string, &sprite_string);
             text.translation = Vec2::new(x as f32, (-y - 75) as f32);
             text.font_size = 22.0;
         }
     }
 
-    game.run(());
+    game.run(GameState {});
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -4,6 +4,7 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     timer: Timer,
 }
@@ -47,7 +48,7 @@ fn main() {
     scale.translation = Vec2::new(400.0, -230.0);
 
     let game_state = GameState {
-        timer: Timer::from_seconds(0.2, true),
+        timer: Timer::from_seconds(0.2, TimerMode::Repeating),
     };
     game.add_logic(game_logic);
     game.run(game_state);
@@ -55,7 +56,7 @@ fn main() {
 
 fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
     if game_state.timer.tick(engine.delta).just_finished() {
-        let mut fps = engine.texts.get_mut("fps").unwrap();
+        let fps = engine.texts.get_mut("fps").unwrap();
         fps.value = format!("FPS: {:.1}", 1.0 / engine.delta_f32);
     }
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -4,6 +4,9 @@
 
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
+struct GameState {}
+
 fn main() {
     let mut game = Game::new();
 
@@ -26,5 +29,5 @@ fn main() {
         "message",
         "This is a heavily-customized window.\nYou may resize it a little bit.\nPress Esc to exit.",
     );
-    game.run(());
+    game.run(GameState {});
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -10,24 +10,20 @@ struct GameState {}
 fn main() {
     let mut game = Game::new();
 
-    game.window_settings(WindowDescriptor {
-        width: 800.0,
-        height: 200.0,
-        resize_constraints: WindowResizeConstraints {
-            min_width: 700.0,
-            min_height: 150.0,
-            max_width: 900.0,
-            max_height: 300.0,
-        },
+    let mut cursor = Cursor::default();
+    cursor.visible = false;
+
+    game.window_settings(Window {
+        resolution: WindowResolution::new(800.0, 200.0),
         title: "Custom Window Settings".into(),
-        resizable: true,
+        resizable: false,
         decorations: false,
-        cursor_visible: false,
-        ..Default::default() // for the rest of the options, see https://docs.rs/bevy/0.5.0/bevy/window/struct.WindowDescriptor.html
+        cursor,
+        ..Default::default() // for the rest of the options, see https://docs.rs/bevy/0.11.3/bevy/window/struct.Window.html
     });
     let _ = game.add_text(
         "message",
-        "This is a heavily-customized window.\nYou may resize it a little bit.\nPress Esc to exit.",
+        "This is a heavily-customized window.\nResizing and window decorations have been disabled.\nPress Esc to exit.",
     );
     game.run(GameState {});
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -19,7 +19,7 @@ fn main() {
         resizable: false,
         decorations: false,
         cursor,
-        ..Default::default() // for the rest of the options, see https://docs.rs/bevy/0.11.3/bevy/window/struct.Window.html
+        ..Default::default() // for the rest of the options, see https://docs.rs/bevy/0.10.1/bevy/index.html
     });
     let _ = game.add_text(
         "message",

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -247,7 +247,7 @@ pub fn queue_managed_audio_system(
         );
     }
     #[allow(clippy::for_loops_over_fallibles)]
-    for item in game_state.audio_manager.music_queue.drain(..).last() {
+    if let Some(item) = game_state.audio_manager.music_queue.drain(..).last() {
         // stop any music currently playing
         if let Some(sink_handle) = &game_state.audio_manager.playing {
             if let Some(sink) = audio_sinks.get(sink_handle) {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -242,9 +242,8 @@ pub fn queue_managed_audio_system(
     mut game_state: ResMut<Engine>,
 ) {
     for (sfx, volume) in game_state.audio_manager.sfx_queue.drain(..) {
-        let sfx_path = format!("audio/{}", sfx);
         commands.spawn(AudioBundle {
-            source: asset_server.load(sfx_path.as_str()),
+            source: asset_server.load(format!("audio/{}", sfx)),
             settings: PlaybackSettings {
                 mode: PlaybackMode::Despawn,
                 volume: Volume::new_relative(volume),
@@ -261,10 +260,9 @@ pub fn queue_managed_audio_system(
         }
         // start the new music...if we have some
         if let Some((music, volume)) = item {
-            let music_path = format!("audio/{}", music);
             let entity = commands
                 .spawn(AudioBundle {
-                    source: asset_server.load(music_path.as_str()),
+                    source: asset_server.load(format!("audio/{}", music)),
                     settings: PlaybackSettings {
                         volume: Volume::new_relative(volume),
                         mode: PlaybackMode::Loop,

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -61,7 +61,7 @@ pub struct AudioManagerPlugin;
 
 impl Plugin for AudioManagerPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app.add_system(queue_managed_audio_system);
+        app.add_systems(Update, queue_managed_audio_system);
     }
 }
 
@@ -231,7 +231,7 @@ impl From<MusicPreset> for String {
 }
 
 #[derive(Component)]
-struct Music;
+pub struct Music;
 
 /// The Bevy system that checks to see if there is any audio management that needs to be done.
 #[doc(hidden)]
@@ -271,6 +271,7 @@ pub fn queue_managed_audio_system(
                         ..Default::default()
                     },
                 })
+                .insert(Music)
                 .id();
             game_state.audio_manager.playing = Some(entity);
         }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -251,7 +251,7 @@ pub fn queue_managed_audio_system(
             },
         });
     }
-    #[allow(clippy::for_loops_over_fallibles)]
+    #[allow(for_loops_over_fallibles)]
     if let Some(item) = game_state.audio_manager.music_queue.drain(..).last() {
         // stop any music currently playing
         if let Ok((entity, music)) = music_query.get_single() {

--- a/src/game.rs
+++ b/src/game.rs
@@ -316,18 +316,24 @@ impl<S: Resource + Send + Sync + 'static> Game<S> {
                     })
                     .set(ImagePlugin::default_nearest()),
             )
-            .add_system(close_on_esc)
+            .add_systems(
+                Update,
+                (
+                    (close_on_esc),
+                    (update_window_dimensions, game_logic_sync::<S>),
+                ),
+            )
             // External Plugins
-            .add_plugin(ShapePlugin) // bevy_prototype_lyon, for displaying sprite colliders
+            .add_plugins(ShapePlugin) // bevy_prototype_lyon, for displaying sprite colliders
             // Rusty Engine Plugins
-            .add_plugin(AudioManagerPlugin)
-            .add_plugin(KeyboardPlugin)
-            .add_plugin(MousePlugin)
-            .add_plugin(PhysicsPlugin)
+            .add_plugins((
+                AudioManagerPlugin,
+                KeyboardPlugin,
+                MousePlugin,
+                PhysicsPlugin,
+            ))
             //.insert_resource(ReportExecutionOrderAmbiguities) // for debugging
-            .add_system(update_window_dimensions)
-            .add_system(game_logic_sync::<S>) // this should happen after all the rest of the systems
-            .add_startup_system(setup);
+            .add_systems(Startup, setup);
         self.app.world.spawn(Camera2dBundle::default());
         let engine = std::mem::take(&mut self.engine);
         self.app.insert_resource(engine);

--- a/src/game.rs
+++ b/src/game.rs
@@ -170,7 +170,7 @@ fn add_collider_lines(commands: &mut Commands, sprite: &mut Sprite) {
             .spawn((
                 ShapeBundle {
                     path: GeometryBuilder::new().add(&line).build(),
-                    transform,
+                    spatial: SpatialBundle::from_transform(transform),
                     ..Default::default()
                 },
                 Stroke::new(Color::WHITE, 1.0 / transform.scale.x),
@@ -220,7 +220,7 @@ pub fn add_texts(commands: &mut Commands, asset_server: &Res<AssetServer>, engin
                 text: BevyText::from_section(
                     text_string,
                     TextStyle {
-                        font: asset_server.load(font_path.as_str()),
+                        font: asset_server.load(font_path),
                         font_size,
                         color: Color::WHITE,
                     },
@@ -307,6 +307,8 @@ impl<S: Resource + Send + Sync + 'static> Game<S> {
     pub fn run(&mut self, initial_game_state: S) {
         self.app.insert_resource::<S>(initial_game_state);
         self.app
+            // TODO: Remove this to use the new, darker default color once the videos have been remastered
+            .insert_resource(ClearColor(Color::rgb(0.4, 0.4, 0.4)))
             // Built-ins
             .add_plugins(
                 DefaultPlugins
@@ -386,7 +388,7 @@ fn game_logic_sync<S: Resource + Send + Sync + 'static>(
 
     // Copy all collision events over to the engine to give to users
     engine.collision_events.clear();
-    for collision_event in collision_events.iter() {
+    for collision_event in collision_events.read() {
         engine.collision_events.push(collision_event.clone());
     }
 
@@ -478,7 +480,7 @@ fn game_logic_sync<S: Resource + Send + Sync + 'static>(
             if text.font_size != bevy_text_component.sections[0].style.font_size {
                 bevy_text_component.sections[0].style.font_size = text.font_size;
             }
-            let font = asset_server.load(text.font.as_str());
+            let font = asset_server.load(text.font.clone());
             if bevy_text_component.sections[0].style.font != font {
                 bevy_text_component.sections[0].style.font = font;
             }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -11,8 +11,8 @@ pub(crate) struct KeyboardPlugin;
 impl Plugin for KeyboardPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource::<KeyboardState>(KeyboardState::default())
-            .add_system(sync_keyboard_events.before("game_logic_sync"))
-            .add_system(sync_keyboard_state.before("game_logic_sync"));
+            .add_system(sync_keyboard_events)
+            .add_system(sync_keyboard_state);
     }
 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -24,7 +24,7 @@ fn sync_keyboard_events(
     engine.keyboard_events.clear();
 
     // Populate this frame's events
-    for event in keyboard_input_events.iter() {
+    for event in keyboard_input_events.read() {
         engine.keyboard_events.push(event.clone());
     }
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -11,8 +11,7 @@ pub(crate) struct KeyboardPlugin;
 impl Plugin for KeyboardPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource::<KeyboardState>(KeyboardState::default())
-            .add_system(sync_keyboard_events)
-            .add_system(sync_keyboard_state);
+            .add_systems(Update, (sync_keyboard_events, sync_keyboard_state));
     }
 }
 
@@ -264,11 +263,11 @@ const KEYCODEVARIANTS: [KeyCode; 163] = [
     Grave,
     Kana,
     Kanji,
-    LAlt,
-    LBracket,
-    LControl,
-    LShift,
-    LWin,
+    AltLeft,
+    BracketLeft,
+    ControlLeft,
+    ShiftLeft,
+    SuperLeft,
     Mail,
     MediaSelect,
     MediaStop,
@@ -276,8 +275,8 @@ const KEYCODEVARIANTS: [KeyCode; 163] = [
     NumpadMultiply,
     Mute,
     MyComputer,
-    NavigateForward,  // also called "Prior"
-    NavigateBackward, // also called "Next"
+    NavigateForward,
+    NavigateBackward,
     NextTrack,
     NoConvert,
     NumpadComma,
@@ -288,11 +287,11 @@ const KEYCODEVARIANTS: [KeyCode; 163] = [
     PlayPause,
     Power,
     PrevTrack,
-    RAlt,
-    RBracket,
-    RControl,
-    RShift,
-    RWin,
+    AltRight,
+    BracketRight,
+    ControlRight,
+    ShiftRight,
+    SuperRight,
     Semicolon,
     Slash,
     Sleep,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -97,7 +97,7 @@ impl KeyboardStateChain {
 
 /// Represents the end-state of all keys during the last frame. Access it through
 /// [`Engine.keyboard_state`](crate::prelude::Engine) in your game logic function.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Resource)]
 pub struct KeyboardState {
     this_frame: HashMap<KeyCode, bool>,
     last_frame: HashMap<KeyCode, bool>,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -25,7 +25,7 @@ fn sync_keyboard_events(
 
     // Populate this frame's events
     for event in keyboard_input_events.read() {
-        engine.keyboard_events.push(event.clone());
+        engine.keyboard_events.push(*event);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! use rusty_engine::prelude::*;
 //!
 //! // Define a struct to hold custom data for your game (it can be a lot more complicated than this one!)
+//! #[derive(Resource)]
 //! struct GameState {
 //!     health: i32,
 //! }
@@ -24,7 +25,7 @@
 //!     // Set up your game. `Game` exposes all of the methods and fields of `Engine`.
 //!     let sprite = game.add_sprite("player", SpritePreset::RacingCarBlue);
 //!     sprite.scale = 2.0;
-//!     game.audio_manager.play_music(MusicPreset::Classy8Bit, 1.0);
+//!     game.audio_manager.play_music(MusicPreset::Classy8Bit, 0.1);
 //!     // Add one or more functions with logic for your game. When the game is run, the logic
 //!     // functions will run in the order they were added.
 //!     game.add_logic(game_logic);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub mod prelude {
         DOWN, EAST, LEFT, NORTH, NORTH_EAST, NORTH_WEST, RIGHT, SOUTH, SOUTH_EAST, SOUTH_WEST, UP,
         WEST,
     };
+    pub use bevy::ecs as bevy_ecs;
     pub use bevy::{
         self,
         prelude::{Resource, Time, Timer, TimerMode, Vec2},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub mod prelude {
     };
     pub use bevy::{
         self,
-        prelude::{Time, Timer, Vec2},
+        prelude::{Resource, Time, Timer, TimerMode, Vec2},
     };
 }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -17,8 +17,7 @@ pub(crate) struct MousePlugin;
 impl Plugin for MousePlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource(MouseState::default())
-            .add_system(sync_mouse_state)
-            .add_system(sync_mouse_events);
+            .add_systems(Update, (sync_mouse_state, sync_mouse_events));
     }
 }
 
@@ -199,7 +198,8 @@ fn sync_mouse_events(
         let mut new_event = ev.clone();
         // Convert from screen space to game space
         // TODO: Check to see if this needs to be adjusted for different DPIs
-        new_event.position -= game_state.window_dimensions * 0.5;
+        new_event.position.x -= game_state.window_dimensions.x * 0.5;
+        new_event.position.y = -new_event.position.y + (game_state.window_dimensions.y * 0.5);
         game_state.mouse_location_events.push(new_event);
     }
     for ev in mouse_motion_events.iter() {
@@ -225,7 +225,9 @@ fn sync_mouse_state(
     // Only changes when we get a new event, otherwise we preserve the last location.
     if let Some(event) = cursor_moved_events.iter().last() {
         // Convert from bevy's window space to our game space
-        let location = event.position - game_state.window_dimensions * 0.5;
+        let mut location = event.position.clone();
+        location.x -= game_state.window_dimensions.x * 0.5;
+        location.y = -location.y + (game_state.window_dimensions.y * 0.5);
         mouse_state.location = Some(location);
     }
     // Sync the relative mouse motion. This is the cumulative relative motion during the last frame.

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -102,7 +102,7 @@ impl MouseStateChain {
 /// If you need to process all mouse events that occurred during a single frame, use the
 /// `mouse_button_events`, `mouse_location_events`, `mouse_motion_events`, or `mouse_wheel_events`
 /// fields on [`Engine`](crate::prelude::Engine).
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Resource)]
 pub struct MouseState {
     location: Option<Vec2>,
     motion: Vec2,

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -191,10 +191,10 @@ fn sync_mouse_events(
     game_state.mouse_wheel_events.clear();
 
     // Populate this frame's events
-    for ev in mouse_button_events.iter() {
+    for ev in mouse_button_events.read() {
         game_state.mouse_button_events.push(ev.clone());
     }
-    for ev in cursor_moved_events.iter() {
+    for ev in cursor_moved_events.read() {
         let mut new_event = ev.clone();
         // Convert from screen space to game space
         // TODO: Check to see if this needs to be adjusted for different DPIs
@@ -202,12 +202,12 @@ fn sync_mouse_events(
         new_event.position.y = -new_event.position.y + (game_state.window_dimensions.y * 0.5);
         game_state.mouse_location_events.push(new_event);
     }
-    for ev in mouse_motion_events.iter() {
+    for ev in mouse_motion_events.read() {
         let mut ev2 = ev.clone();
         ev2.delta.y *= -1.0;
         game_state.mouse_motion_events.push(ev2.clone());
     }
-    for ev in mouse_wheel_events.iter() {
+    for ev in mouse_wheel_events.read() {
         game_state.mouse_wheel_events.push(ev.clone());
     }
 }
@@ -223,7 +223,7 @@ fn sync_mouse_state(
 ) {
     // Sync the current mouse location, which will be the last cursor_moved event that occurred.
     // Only changes when we get a new event, otherwise we preserve the last location.
-    if let Some(event) = cursor_moved_events.iter().last() {
+    if let Some(event) = cursor_moved_events.read().last() {
         // Convert from bevy's window space to our game space
         let mut location = event.position.clone();
         location.x -= game_state.window_dimensions.x * 0.5;
@@ -232,7 +232,7 @@ fn sync_mouse_state(
     }
     // Sync the relative mouse motion. This is the cumulative relative motion during the last frame.
     mouse_state.motion = Vec2::ZERO;
-    for ev in mouse_motion_events.iter() {
+    for ev in mouse_motion_events.read() {
         // Convert motion to game space direction (positive y is up, not down)
         // TODO: Check to see if this needs to be adjusted for different DPIs
         let mut ev2 = ev.clone();
@@ -243,7 +243,7 @@ fn sync_mouse_state(
     mouse_state.wheel = MouseWheelState::default();
     let mut cumulative_x = 0.0;
     let mut cumulative_y = 0.0;
-    for ev in mouse_wheel_events.iter() {
+    for ev in mouse_wheel_events.read() {
         cumulative_x += ev.x;
         cumulative_y += ev.y;
     }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -192,7 +192,7 @@ fn sync_mouse_events(
 
     // Populate this frame's events
     for ev in mouse_button_events.read() {
-        game_state.mouse_button_events.push(ev.clone());
+        game_state.mouse_button_events.push(*ev);
     }
     for ev in cursor_moved_events.read() {
         let mut new_event = ev.clone();
@@ -203,12 +203,12 @@ fn sync_mouse_events(
         game_state.mouse_location_events.push(new_event);
     }
     for ev in mouse_motion_events.read() {
-        let mut ev2 = ev.clone();
+        let mut ev2 = *ev;
         ev2.delta.y *= -1.0;
-        game_state.mouse_motion_events.push(ev2.clone());
+        game_state.mouse_motion_events.push(ev2);
     }
     for ev in mouse_wheel_events.read() {
-        game_state.mouse_wheel_events.push(ev.clone());
+        game_state.mouse_wheel_events.push(*ev);
     }
 }
 
@@ -225,7 +225,7 @@ fn sync_mouse_state(
     // Only changes when we get a new event, otherwise we preserve the last location.
     if let Some(event) = cursor_moved_events.read().last() {
         // Convert from bevy's window space to our game space
-        let mut location = event.position.clone();
+        let mut location = event.position;
         location.x -= game_state.window_dimensions.x * 0.5;
         location.y = -location.y + (game_state.window_dimensions.y * 0.5);
         mouse_state.location = Some(location);
@@ -235,7 +235,7 @@ fn sync_mouse_state(
     for ev in mouse_motion_events.read() {
         // Convert motion to game space direction (positive y is up, not down)
         // TODO: Check to see if this needs to be adjusted for different DPIs
-        let mut ev2 = ev.clone();
+        let mut ev2 = *ev;
         ev2.delta.y *= -1.0;
         mouse_state.motion += ev2.delta;
     }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -17,8 +17,8 @@ pub(crate) struct MousePlugin;
 impl Plugin for MousePlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource(MouseState::default())
-            .add_system(sync_mouse_state.before("game_logic_sync"))
-            .add_system(sync_mouse_events.before("game_logic_sync"));
+            .add_system(sync_mouse_state)
+            .add_system(sync_mouse_events);
     }
 }
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -14,7 +14,7 @@ pub(crate) struct PhysicsPlugin;
 impl Plugin for PhysicsPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<CollisionEvent>()
-            .add_system(collision_detection);
+            .add_systems(Update, collision_detection);
     }
 }
 
@@ -25,7 +25,7 @@ impl Plugin for PhysicsPlugin {
 /// [Sprite]s which:
 /// - have colliders (you can use the `collider` example to create your own colliders)
 /// - have their `collision` flags set to `true`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Event)]
 pub struct CollisionEvent {
     pub state: CollisionState,
     pub pair: CollisionPair,

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -172,16 +172,11 @@ fn collision_detection(
 /// Represents the collider (or lack thereof) of a sprite. Two sprites need to have colliders AND
 /// have their `Sprite.collision` fields set to `true` to generate collision events. See the
 /// `collider` example to create your own colliders
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub enum Collider {
+    #[default]
     NoCollider,
     Poly(Vec<Vec2>),
-}
-
-impl Default for Collider {
-    fn default() -> Self {
-        Collider::NoCollider
-    }
 }
 
 impl Collider {
@@ -341,7 +336,7 @@ impl Collider {
             let poly2 = sprite2.collider.relative_to(sprite2);
             // Polygon intersection algorithm adapted from
             // https://stackoverflow.com/questions/10962379/how-to-check-intersection-between-2-rotated-rectangles
-            for poly in vec![poly1.clone(), poly2.clone()] {
+            for poly in [poly1.clone(), poly2.clone()] {
                 for (idx, &p1) in poly.iter().enumerate() {
                     let p2 = poly[(idx + 1) % poly.len()];
                     let normal = Vec2::new(p2.y - p1.y, p1.x - p2.x);

--- a/tutorial/src/00-welcome.md
+++ b/tutorial/src/00-welcome.md
@@ -2,10 +2,10 @@
 
 Rusty Engine is a simple, 2D game engine for those who are learning Rust. Create simple game prototypes using straightforward Rust code without needing to learning difficult game engine concepts! It works on macOS, Linux, and Windows. Rusty Engine is a simplification wrapper over [Bevy](https://bevyengine.org/), which I encourage you to use directly for more serious game engine needs.
 
-The following courses use Rusty Engine in their curriculum:
+The following courses currently use Rusty Engine in their curriculum:
 
-- [Ultimate Rust 2: Intermediate Concepts](https://www.udemy.com/course/ultimate-rust-2/?referralCode=8ED694EBE5637F954414) on Udemy (the sequel to [Ultimate Rust Crash Course](https://www.udemy.com/course/ultimate-rust-crash-course/?referralCode=AF30FAD8C6CCCC2C94F0))
-- [Rust in 3 Weeks](https://agileperception.com) conducted live on O'Reilly Online approximately once each quarter.
+- [Ultimate Rust 2: Intermediate Concepts](https://agileperception.com/ultimate_rust_2) (the sequel to [Ultimate Rust Crash Course](https://agileperception.com/ultimate_rust_crash_course))
+
 
 # Tutorial
 

--- a/tutorial/src/02-quick-start.md
+++ b/tutorial/src/02-quick-start.md
@@ -1,6 +1,6 @@
 # Quick Start Example
 
-- Create a new Rust project and add `rusty_engine` as a dependency (see the [Configuration](05-config.md) page for more details)
+- Create a new Rust project and run `cargo add rusty_engine` to add Rusty Engine as a dependency (see the [Configuration](05-config.md) page for more details). Your `Cargo.toml` file should end up with a line similar to this:
 ```toml
 # In your [dependencies] section of Cargo.toml
 rusty_engine = "5.2.1"
@@ -13,48 +13,44 @@ curl -L https://github.com/CleanCut/rusty_engine/archive/refs/heads/main.tar.gz 
 
 ```rust,ignore
 // in src/main.rs
- use rusty_engine::prelude::*;
-
- // Define a struct to hold custom data for your game (it can be a lot more complicated than this one!)
- struct GameState {
-     health: i32,
- }
-
- fn main() {
-     // Create a game
-     let mut game = Game::new();
-
-     // Set up your game. `Game` exposes all of the methods and fields of `Engine`
-     let sprite = game.add_sprite("player", SpritePreset::RacingCarBlue);
-     sprite.scale = 2.0;
-
-     game.audio_manager.play_music(MusicPreset::Classy8Bit, 1.0);
-
-     // Add one or more functions with logic for your game. When the game is run, the logic
-     // functions will run in the order they were added.
-     game.add_logic(game_logic);
-
-     // Run the game, with an initial state
-     game.run(GameState { health: 100 });
- }
-
- // Your game logic functions can be named anything, but the first parameter is always a
- // `&mut Engine`, and the second parameter is a mutable reference to your custom game
- // state struct (`&mut GameState` in this case). The function returns a `bool`.
- //
- // This function will be run once each frame.
- fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
-     // The `Engine` contains all sorts of built-in goodies.
-     // Get access to the player sprite...
-     let player = engine.sprites.get_mut("player").unwrap();
-     // Rotate the player...
-     player.rotation += std::f32::consts::PI * engine.delta_f32;
-     // Damage the player if it is out of bounds...
-     if player.translation.x > 100.0 {
-         game_state.health -= 1;
-     }
- }
- ```
+use rusty_engine::prelude::*;
+// Define a struct to hold custom data for your game. If you don't yet know what data fields you
+// need, it can be an empty struct. It must have `#[derive(Resource)]` on the line before it.
+#[derive(Resource)]
+struct GameState {
+    health: i32, // add any fields you want, or leave the struct without fields
+}
+fn main() {
+    // Create a game
+    let mut game = Game::new();
+    // Set up your game. `Game` exposes all of the methods and fields of `Engine`
+    let sprite = game.add_sprite("player", SpritePreset::RacingCarBlue);
+    sprite.scale = 2.0;
+    // Start some music!
+    game.audio_manager.play_music(MusicPreset::Classy8Bit, 1.0);
+    // Add one or more functions with logic for your game. When the game is run, the logic
+    // functions will run in the order they were added.
+    game.add_logic(game_logic);
+    // Run the game, with an initial state
+    game.run(GameState { health: 100 });
+}
+// Your game logic functions can be named anything, but the first parameter is always a
+// `&mut Engine`, and the second parameter is a mutable reference to your custom game
+// state struct (`&mut GameState` in this case). The function returns a `bool`.
+//
+// This function will be run once each frame.
+fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
+    // The `Engine` contains all sorts of built-in goodies.
+    // Get access to the player sprite...
+    let player = engine.sprites.get_mut("player").unwrap();
+    // Rotate the player...
+    player.rotation += std::f32::consts::PI * engine.delta_f32;
+    // Damage the player if it is out of bounds...
+    if player.translation.x > 100.0 {
+        game_state.health -= 1;
+    }
+}
+```
 
 - Run your game with `cargo run --release`.  Don't forget the `--release`!
 

--- a/tutorial/src/05-config.md
+++ b/tutorial/src/05-config.md
@@ -1,7 +1,7 @@
 # Configuration
 
 - Create a new Rust project
-- In your `Cargo.toml` file, add `rusty_engine` to your `[dependencies]` section:
+- Do `cargo add rusty_engine` to add the latest version of Rusty Engine to the `[dependencies]` section of your `Cargo.toml`. It should add a line that looks something like this:
 
 ```toml
 # In your [dependencies] section of Cargo.toml

--- a/tutorial/src/10-assets.md
+++ b/tutorial/src/10-assets.md
@@ -3,7 +3,7 @@
 Rusty Engine assumes the asset pack is present, so you MUST download the asset pack.
 
 Here are three different ways to download the assets (pick any of them--it should end up the same in the end):
-- RECOMMENDED: On a posix compatible shells run this command inside your project directory:
+- RECOMMENDED: In your terminal with a posix-compatible shell, run this command inside your project directory:
 ```shell
 curl -L https://github.com/CleanCut/rusty_engine/archive/refs/heads/main.tar.gz | tar -zxv --strip-components=1 rusty_engine-main/assets
 ```
@@ -27,7 +27,7 @@ assets
     └── rolling
 ```
 
-You can organize your own custom files wherever you like, but the asset pack will always be organized like this:
+You can organize your own custom files inside the `assets` folder wherever you like, but the provided asset pack is organized like this:
 
 - Audio files in `assets/audio`. The asset pack divides sounds into `music` and `sfx` subdirectories.
 - Font files in `assets/font`.

--- a/tutorial/src/105-keyboard-state.md
+++ b/tutorial/src/105-keyboard-state.md
@@ -2,9 +2,9 @@
 
 You can think of keyboard _state_ as a snapshot of exactly which keys are pressed (or not) at the start of the frame. Keyboard state is best for interactive things like character movement.  If you need to process every single keystroke (like when entering text), check out the [Keyboard Event](110-keyboard-events.md) section instead.
 
-The `Engine.keyboard_state` field is a struct through which you query the state of the key(s) you are interested in.
+The `Engine` struct's `keyboard_state` field is a struct through which you query the state of the key(s) you are interested in.
 
-Rusty Engine exposes [Bevy](https://bevyengine.org/)'s [`KeyCode`](https://docs.rs/bevy/latest/bevy/input/keyboard/enum.KeyCode.html) enum directly. See [the `KeyCode` documentation](https://docs.rs/bevy/latest/bevy/input/keyboard/enum.KeyCode.html) for all the possible key variants.
+Rusty Engine exposes [Bevy](https://bevyengine.org/)'s [`KeyCode`](https://docs.rs/bevy/latest/bevy/input/keyboard/enum.KeyCode.html) enum through its prelude. See [the `KeyCode` documentation](https://docs.rs/bevy/latest/bevy/input/keyboard/enum.KeyCode.html) for all the possible key variants.
 
 ### Pressed / Released
 
@@ -54,7 +54,7 @@ if engine.keyboard_state.just_pressed_any(&[KeyCode::Q, KeyCode::F1]) {
     // open menu
 }
 if engine.keyboard_state.just_released_any(&[KeyCode::Space, KeyCode::LControl]) {
-    // reevaluate your life choices
+    // re-evaluate your life choices
 }
 ```
 

--- a/tutorial/src/110-keyboard-events.md
+++ b/tutorial/src/110-keyboard-events.md
@@ -6,8 +6,8 @@ Keyboard events are passed through from Bevy as instances of the [`KeyboardInput
 
 ```rust,ignored
 for keyboard_event in game_state.keyboard_events.drain(..) {
-    // We're using `if let` and a pattern to both destructure the struct and at the
-    // same time match "Pressed" events containing some key code.
+    // We're using `if let` and a pattern to destructure the KeyboardInput struct and only look at
+    // keyboard input if the state is "Pressed". Then we match on the KeyCode and take action.
     if let KeyboardInput {
         scan_code: _,
         key_code: Some(key_code),

--- a/tutorial/src/115-mouse-state.md
+++ b/tutorial/src/115-mouse-state.md
@@ -1,8 +1,8 @@
 # Mouse State
 
-Everything said about the [Keyboard State](105-keyboard-state.md) is true for Mouse State as well, just for your mouse instead of your keyboard. Mouse state is perfect for character movement or game controls such as buttons. If you need to process every bit of mouse input, such as all the locations the mouse was in since the beginning of the last frame, then you'll need to look at [Mouse Events](120-mouse-events.md) instead.
+Everything said about the [Keyboard State](105-keyboard-state.md) is true for Mouse State as well, just for your mouse instead of your keyboard. Mouse state is perfect for character movement or game controls such as buttons. If you need to process every bit of mouse input, such as all the locations the mouse was at since the beginning of the last frame, then you'll need to look at [Mouse Events](120-mouse-events.md) instead.
 
-All mouse state is stored in the `Engine.mouse_state`, and queried via methods.
+All mouse state is stored in the `Engine` struct's `mouse_state` field, and queried via methods.
 
 ### Mouse Buttons
 
@@ -37,9 +37,9 @@ if engine.mouse_state.just_released_any(&[MouseButton::Left, MouseButton::Middle
 
 ### Location
 
-Use the `location` method to see where the mouse is. It returns an `Option<Vec2>`. If `None` is returned, then the mouse pointer isn't in the window. If present, the `Vec2` value is in the same 2D world coordinate system as the rest of the game. See the [section on sprite translation](60-sprite-placement.html) for more info about `Vec2` or the world coordinate system.
+Use the `location` method to see where the mouse is. It returns an `Option<Vec2>`. If `None` is returned, then either the window isn't focused or the mouse pointer isn't in the window. If present, the `Vec2` value is in the same 2D world coordinate system as the rest of the game. See the [section on sprite translation](60-sprite-placement.html) for more info about `Vec2` or the world coordinate system.
 
-It is easy to demonstrate `location` by having a sprite appear wherever your mouse is located:
+A fun way to demonstrate mouse `location` is by having a sprite appear wherever your mouse is located:
 
 ```rust,ignored
 // `player` is a sprite
@@ -50,7 +50,7 @@ if let Some(location) = engine.mouse_state.location() {
 
 ### Motion
 
-The relative motion that the mouse moved last frame is accumulated into a single `Vec2`. This could be useful if you want to base some logic over how fast or in which direction the mouse is moving.
+The relative motion that the mouse moved last frame is accumulated into a single `Vec2`. This could be useful if you want to base some logic on how fast or in which direction the mouse is moving.
 
 ```rust,ignored
 let motion = engine.mouse_state.motion();

--- a/tutorial/src/120-mouse-events.md
+++ b/tutorial/src/120-mouse-events.md
@@ -6,7 +6,7 @@ Mouse events are most useful when you want to process multiple events that happe
 
 ### Mouse button events
 
-You usually want to use [mouse state](115-mouse-state.md) for mouse buttons, which are less awkward to deal with than mouse events when you only care about the state the mouse ended up in at the end of the frame. Mouse events are available in the `Engine.mouse_button_events` vector. The Bevy struct [`MouseButtonInput`](https://docs.rs/rusty_engine/latest/rusty_engine/mouse/struct.MouseButtonInput.html) is used for the event value.  Here is an example of using mouse button events to rotate a sprite by a fixed amount for each click. This is guaranteed not to miss any clicks in the (unlikely) event that two clicks come in on the same frame.
+You usually want to use [mouse state](115-mouse-state.md) for mouse buttons, which are less awkward to deal with than mouse events when you only care about the state the mouse ended up in at the end of the frame. Mouse events are available in the `Engine` struct's `mouse_button_events` field, which is a vector of mouse button input events. The Bevy struct [`MouseButtonInput`](https://docs.rs/rusty_engine/latest/rusty_engine/mouse/struct.MouseButtonInput.html) is used for the event value.  Here is an example of using mouse button events to rotate a sprite by a fixed amount for each click. This is guaranteed not to miss any clicks in the (unlikely) event that two clicks come in on the same frame.
 
 
 ```rust,ignored
@@ -26,7 +26,7 @@ for mouse_button_input in &engine.mouse_button_events {
 
 Mouse location events are most useful if you are trying to capture all the points the mouse was at during the frame. Unlike mouse button events, there are *often* multiple mouse location events, since moving the mouse produces a series of events for each location that the mouse cursor is rendered on screen. If you only care about the final location of the mouse during the frame, you should use [mouse state](115-mouse-state.md) instead.
 
-Mouse location events are accessed through the `Engine.mouse_location_events` vector and contain the [`CursorMoved`](https://docs.rs/rusty_engine/latest/rusty_engine/mouse/struct.CursorMoved.html) struct re-exported from Bevy. If one wanted to draw a trail of sparkles wherever a mouse went, mouse location events might be a good source of data:
+Mouse location events are accessed through the `Engine.mouse_location_events` vector and contain the [`CursorMoved`](https://docs.rs/rusty_engine/latest/rusty_engine/mouse/struct.CursorMoved.html) struct re-exported from Bevy. If you want to draw a trail of sparkles wherever a mouse went, mouse location events might be a good source of data:
 
 ```rust,ignored
 for cursor_moved in &engine.mouse_location_events {

--- a/tutorial/src/15-init.md
+++ b/tutorial/src/15-init.md
@@ -6,11 +6,12 @@ Rusty Engine has a prelude which you should import in `main.rs`:
 use rusty_engine::prelude::*;
 ```
 
-You should usually define a [`GameState`](20-game-state.md) struct (which we'll go over in the [game state section](20-game-state.md)). This will be a struct that you store your game-specific data in. Things like high score, player name, health left, etc.
+You must define a [`GameState`](20-game-state.md) struct (which we'll go over in the [game state section](20-game-state.md)). This will be a struct that you store your game-specific data. Things like high score, player name, health left, etc. You must put the line `#[derive(Resource)]` above your struct definition.
 
 ```rust,ignore
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     health_left: i32,
 }
@@ -30,16 +31,7 @@ fn main() {
 
 Use your `Game` instance to set up your game and register logic functions to run each frame.
 
-At the end of main you will run your game with `Game::run()`. The `run` method takes an initial game state. If you didn't define a game state struct, then just give it a unit struct `()`:
-
-```rust,ignore
-fn main() {
-    // ...
-    game.run(());
-}
-```
-
-If you did define a game state struct (we'll assume you named it `GameState`), then pass `run` a value of that type:
+At the end of main you will run your game with `Game::run()`. The `run` method takes an initial game state, so provide an instance of your `GameState` struct:
 
 ```rust,ignore
 fn main() {
@@ -48,6 +40,16 @@ fn main() {
 }
 ```
 
+If you didn't define any fields for your `GameState` struct (like above, we had a `health_left` field), the syntax looks like this:
+
+```rust,ignore
+fn main() {
+    // ...
+    game.run(GameState {});
+}
+```
+
+
 ## Example
 
 If you put it all together, it looks like this. This example will run and create an empty window, but won't _do_ anything, yet.
@@ -55,6 +57,7 @@ If you put it all together, it looks like this. This example will run and create
 ```rust,ignore
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
     health_left: i32,
 }

--- a/tutorial/src/155-text-creation.md
+++ b/tutorial/src/155-text-creation.md
@@ -10,9 +10,9 @@ let _ = game.add_text("title", "The Fun Game");
 let _ = engine.add_text("score", "Score: 0");
 ```
 
-The first parameter is a unique label. It is used in the same way as sprite labels are used (to identify the text later on). The second parameter is actual string value to render.
+The first parameter is a unique label. It is used in the same way as sprite labels are used (to identify the text later on). The second parameter is the string value to render.
 
-`add_text` returns a mutable reference to a `Text` (`&mut Text`). Note that this is one case where Rusty Engine does _not_ re-export something from Bevy. Bevy has also has a struct named `Text`, but it is entirely a different thing.
+`add_text` returns a mutable reference to a `Text` (`&mut Text`). Note that this is one case where Rusty Engine does _not_ re-export something from Bevy. Bevy has also has a struct named `Text`, but it is entirely a different thing which Rusty Engine does not expose to you.
 
 Since it will emit a warning to silently ignore the mutable reference to the `Text`, you should explicitly ignore it if you are not going to use it by doing `let _ = ...` as in the examples above. However, most of the time you will want to use the mutable reference to immediately adjust your text, as we'll see in the following sections.
 

--- a/tutorial/src/160-text-attributes.md
+++ b/tutorial/src/160-text-attributes.md
@@ -2,16 +2,16 @@
 
 Changing the string value, the chosen font, or the font size causes the `Text` to be re-rendered as a new image at the end of the frame. This is relatively expensive in terms of performance, so you should avoid changing these attributes except when you actually need to.
 
-All existing text values can be accessed through the `Engine.texts` vector.
+All existing text values can be accessed through the `Engine` struct's `texts` field, which is a vector of `Text`s.
 
 
 ### Value
 
-`Text.value` is the actual string that gets rendered to the screen. If you change the value, then the `Text` will be re-rendered as a new image at the end of the frame with the new value.
+The `Text` struct's `value` field is the actual string that gets rendered to the screen. If you change the value, then the `Text` will be re-rendered as a new image at the end of the frame with the new value.
 
 ```rust,ignored
 let score_text = engine.texts.get_mut("score_text").unwrap();
-score_text.value = format!("Score: {}", score);
+score_text.value = format!("Score: {}", score); // The `format` macro produces a String.
 ```
 
 ### Font

--- a/tutorial/src/165-text-placement.md
+++ b/tutorial/src/165-text-placement.md
@@ -6,7 +6,7 @@ In short, feel free to change your text's placement attributes every frame witho
 
 ### Translation
 
-`Text.translation` is a [`Vec2`](https://docs.rs/glam/latest/glam/f32/struct.Vec2.html) containing the X and Y coordinates of your text's position on the screen. This `Vec2` location is in the exact center of the text, both vertically and horizontally. In other words, text is always rendered with "centered" alignment on both axes.
+`Text.translation` is a [`Vec2`](https://docs.rs/glam/latest/glam/f32/struct.Vec2.html) containing the `x` and `y` coordinates of your text's position on the screen. This `Vec2` location is in the exact center of the text, both vertically and horizontally. In other words, text is always rendered with "centered" alignment on both axes.
 
 The coordinate system works just like it does in math class. `(0.0, 0.0)` is in the center of the screen. Positive X goes to the right side of the screen. Positive Y goes to the top of the screen. Every increment of `1.0` is one logical pixel on the screen. Hi-DPI screens may have more than one physical pixel per logical pixel. See the [`Engine`](400-engine.md) section for details on how to check the logical pixel dimensions of your window.
 
@@ -17,9 +17,7 @@ score_text.translation = Vec2::new(400.0, -325.0);
 
 ### Rotation
 
-`Text.rotation`* is an `f32` representing the angle in radians from the positive X axis. In other words, a rotation of `0.0` results in normal, horizontal text along the X axis. A rotation of `PI` would result in upside-down text.
-
-*Bevy 0.5 does not support text rotation, so modifying this field is currently a no-op. Once Bevy 0.6 is released, and Rusty Engine is updated to use it, this will actually worked as described.
+`Text.rotation` is an `f32` representing the angle in radians from the positive X axis. In other words, a rotation of `0.0` results in normal, horizontal text along the X axis. A rotation of `PI` would result in upside-down text.
 
 ```rust,ignored
 let angled = engine.add_text("angled", "This text is at an angle.");
@@ -28,7 +26,7 @@ score_text.rotation = std::f32::consts::PI / 4.0;
 
 ### Scale
 
-`Text.scale`* is an `f32`. `1.0` means matching a pixel of the source image to a pixel on the screen. `2.0` makes the image twice as wide and tall, etc.
+`Text.scale` is an `f32`. `1.0` means matching a pixel of the source image to a pixel on the screen. `2.0` makes the image twice as wide and tall, etc.
 
 Usually, you will want to leave text at a scale of `1.0`, but if you wish to have text zoom or shrink, modifying the scale has two important advantages compared to changing the font size:
 
@@ -37,8 +35,6 @@ Usually, you will want to leave text at a scale of `1.0`, but if you wish to hav
 
 The main drawback of changing the scale is that since the font is not re-rendered, it looks pixellated when scaled up. Though, this could be considered as a stylistic plus as well.
 
-*Bevy 0.5 does not support changing text scale, so modifying this field is currently a no-op. Once Bevy 0.6 is released, and Rusty Engine is updated to use it, this will actually worked as described.
-
 ```rust,ignored
 let zoomed = engine.add_text("zoomed", "This text is twice as big as normal.");
 score_text.scale = 2.0;
@@ -46,7 +42,7 @@ score_text.scale = 2.0;
 
 ### Layer
 
-`Text.layer` is an `f32` that affects what sprite or text is "on top" of another sprite or text when they overlap. `0.0` is the default and "bottom" layer, and `999.0` is the "top" layer. The order of sprites or text on the same layer is random and unstable (can change frame to frame), so you should make sure that sprites and text that will overlap are on different layers. A good practice is to choose a few layers and assign them to constants. For example:
+`Text.layer` is an `f32` that affects what sprite or text is "on top" of another sprite or text when they overlap. `0.0` is the default layer and is on "bottom", and `999.0` is the "top" layer. The order of sprites or text on the same layer is random and unstable (can change frame to frame), so you should make sure that sprites and text that will overlap are on different layers. A good practice is to choose a few layers and assign them to constants. For example:
 
 ```rust,ignored
 const BACKGROUND_LAYER: f32 = 0.0;
@@ -88,7 +84,7 @@ spinning_message.rotation += TURN_SPEED_PER_SEC * engine.delta_f32;
 
 ### Deleting a text
 
-To delete a text, simply remove it from the `Engine.texts` hash map.
+To delete a text, remove it from the `Engine.texts` hash map.
 
 ```rust,ignored
 engine.texts.remove("old_message");

--- a/tutorial/src/20-game-state.md
+++ b/tutorial/src/20-game-state.md
@@ -1,6 +1,6 @@
 # Game State
 
-You will need somewhere to store data for your game that is not part of the engine but that you need access to for more than a single frame. That somewhere is your _game state struct_.  You provide a struct to use for your own game state. Within that struct, you can store just about anything. Some examples of things you may want to put in your game state:
+You will need somewhere to store data for your game between frames. That somewhere is your _game state struct_.  You provide a struct to use for your own game state. Within that struct, you can store just about anything. Some examples of things you may want to put in your game state:
 
 - Player attributes (name, color, health, energy, money, etc.)
 - Game attributes (score, day, turn, etc.)
@@ -9,29 +9,32 @@ You will need somewhere to store data for your game that is not part of the engi
 - Collections of text labels to iterate through and update (maybe text representing current health is placed above your player)
 - Anything else that needs to persist across frames that isn't already stored in the engine
 
-You can name your game state struct whatever you want, but since there can only ever be one game state type, we suggest you call it `GameState` as we will in this tutorial.
+You can name your game state struct whatever you want, but since there can only ever be one game state type, it probably makes sense just to name it `GameState` as we will in this tutorial.
+
+You must always include the line `#[derive(Resource)]` immediately before the `GameState`. This is a requirement from the Bevy game engine which we're using under-the-hood.
 
 Here is an example of a game state you might define for a simple game which keeps track of a current score and a high score, the labels of enemies which need to move around, and a timer for when to spawn a new enemy.
 
 ```rust,ignore
+#[derive(Resource)]
 struct GameState {
-    high_score: u32,
     current_score: u32,
+    high_score: u32,
     enemy_labels: Vec<String>,
     spawn_timer: Timer,
 }
 ```
 
-When you start your game, you will need to pass it an initial value of the game state.  You will receive a mutable reference to this game state value in your logic function(s) each frame.
+When you start your game, you will need to pass it an initial value of the game state.  You will receive a mutable reference to this game state value in your [game logic function](25-game-logic-function.md) each frame.
 
 ```rust,ignore
 fn main() {
     // ...
     let game_state = GameState {
-        high_score: 2345,
         current_score: 0,
+        high_score: 2345,
         enemy_labels: Vec::new(),
-        spawn_timer: Timer::from_seconds(10.0, false),
+        spawn_timer: Timer::from_seconds(10.0, TimerMode::Once),
     };
     game.run(game_state);
 }

--- a/tutorial/src/25-game-logic-function.md
+++ b/tutorial/src/25-game-logic-function.md
@@ -1,6 +1,6 @@
 # Game Logic Function
 
-A game is divided up into _frames_. A _frame_ is one run through your game logic to produce a new image to display on the screen. On most hardware you will usually get about 60 frames each second.  Rusty Engine tries to run your game logic function(s) once each frame.
+A game is divided up into _frames_. A _frame_ is one run through your game logic to produce a new image to display on the screen. On most hardware you will usually get about 60 frames each second.  Rusty Engine tries to run your game logic function once each frame.
 
 A game logic function definition looks like this:
 
@@ -10,23 +10,15 @@ fn game_logic(engine: &mut Engine, game_state: &mut GameState) {
 }
 ```
 
-If you passed in a unit struct for your game state, then use a unit struct in your logic function definition:
+The function may be named anything you want, but we'll always use `game_logic` in this tutorial. However, if you use more than one game logic function, each will need to have a unique name.
 
-```rust,ignore
-fn game_logic(engine: &mut Engine, game_state: &mut ()) {
-    // logic...without any state to look at.
-}
-```
-
-The function may be named anything you want. We used `game_logic` in the example above, which is the conventional name if you only have one. However, if you use more than one game logic function, each will need to have a unique name.
-
-You need to "add" your game logic functions to Rusty Engine by calling `Game::add_logic` in your `main` function:
+You need to "add" your game logic function to Rusty Engine by calling `Game::add_logic` in your `main` function BEFORE running the game with the `run` method:
 
 ```rust,ignore
 game.add_logic(game_logic);
 ```
 
-You can add multiple game logic functions, which will always run in the order they were added. For example, this game will always run the `menu_logic` function first, and then the `game_logic`.
+You can add multiple game logic functions, which will always run in the order they were added. For example, this game will always run the `menu_logic` function first, and then the `game_logic`. Most people just use a single game logic function.
 
 ```rust,ignore
 game.add_logic(menu_logic);
@@ -35,14 +27,15 @@ game.add_logic(game_logic);
 
 ## Example
 
-Here's an example game logic function using the game state from the [game state section](20-game-state.md). It simply increments the score and outputs that score to the console once per frame.
+Here's an example game logic function using the game state from the [game state section](20-game-state.md). The game logic function increments the score and outputs that score to the console once per frame.
 
 ```rust,ignore
 use rusty_engine::prelude::*;
 
+#[derive(Resource)]
 struct GameState {
-    high_score: u32,
     current_score: u32,
+    high_score: u32,
     enemy_labels: Vec<String>,
     spawn_timer: Timer,
 }
@@ -50,10 +43,10 @@ struct GameState {
 fn main() {
     let mut game = Game::new();
     let game_state = GameState {
-        high_score: 2345,
         current_score: 0,
+        high_score: 2345,
         enemy_labels: Vec::new(),
-        spawn_timer: Timer::from_seconds(10.0, false),
+        spawn_timer: Timer::from_seconds(10.0, TimerMode::Once),
     };
     game.add_logic(game_logic); // Don't forget to add the logic function to the game!
     game.run(game_state);

--- a/tutorial/src/250-timer.md
+++ b/tutorial/src/250-timer.md
@@ -6,14 +6,14 @@ Timers are super cheap, performance-wise. Feel free to create them and throw the
 
 ### Creation
 
-It is easy to create a timer with the `from_seconds` method. The first parameter is a number of seconds to countdown, and the second parameter is whether or not the timer is repeating. `false` means the timer will only countdown once, and then remain at `0.0` once finished. `true` means the timer will start counting down again from the same countdown time as soon as it has reached `0.0`.
+It is easy to create a timer with the `from_seconds` method. The first parameter is a number of seconds to countdown, and the second parameter is whether or not the timer is repeating. `TimerMode::Once` means the timer will only countdown once, and then remain at `0.0` once finished. `TimerMode::Repeating` means the timer will start counting down again from the same countdown time as soon as it has reached `0.0`.
 
 ```rust,ignored
 // A one-shot timer.
-let timer_once = Timer::from_seconds(10.0, false);
+let timer_once = Timer::from_seconds(10.0, TimerMode::Once);
 
 // A repeating timer.
-let timer_repeating = Timer::from_seconds(3.0, true);
+let timer_repeating = Timer::from_seconds(3.0, TimerMode::Repeating);
 ```
 
 ### Counting down & Finishing

--- a/tutorial/src/450-game.md
+++ b/tutorial/src/450-game.md
@@ -16,12 +16,12 @@ fn main() {
 
 ### Window Settings
 
-Rusty Engine re-exports the [`WindowDescriptor`](https://docs.rs/rusty_engine/latest/rusty_engine/game/struct.WindowDescriptor.html) struct from Bevy, whose fields are all used to request certain window attributes. Please be aware that these are only _requests_ for configuration, and that the underlying operating system may refuse (or be unable) to give you exactly what you ask for. For example, you may not be able to obtain a window with larger dimensions than the physical monitor.
+Rusty Engine re-exports the [`Window`](https://docs.rs/rusty_engine/latest/rusty_engine/game/struct.Window.html) struct from Bevy, whose fields are all used to request certain window attributes. Please be aware that these are only _requests_ for configuration, and that the underlying operating system may refuse (or be unable) to give you exactly what you ask for. For example, you may not be able to obtain a window with larger dimensions than the physical monitor.
 
-Pass a `WindowDescriptor` to the `window_settings` method to request specific settings for your game window. This is a great time to take advantage of "struct update" syntax so you don't have to re-specify the fields which you aren't customizing.
+Pass a `Window` to the `window_settings` method to request specific settings for your game window. This is a great time to take advantage of "struct update" syntax so you don't have to re-specify the fields which you aren't customizing.
 
 ```rust,ignored
-game.window_settings(WindowDescriptor {
+game.window_settings(Window {
     title: "My Awesome Game".into(),
     width: 800.0,
     height: 200.0,
@@ -34,4 +34,4 @@ Game has an `add_logic` method to add game logic functions to your game. Please 
 
 ### Running the game
 
-The last thing you will do in your main function is to call the `run` method to begin your game. The `run` method takes an instance of whatever game state struct you defined, or a unit struct `()` if you didn't define one.
+The last thing you will do in your main function is to call the `run` method to begin your game. The `run` method takes an instance of whatever game state struct you defined.

--- a/tutorial/src/55-sprite-creation.md
+++ b/tutorial/src/55-sprite-creation.md
@@ -10,10 +10,10 @@ let _ = game.add_sprite("my_player", SpritePreset::RacingCarBlue);
 let _ = engine.add_sprite("my_player", SpritePreset::RacingCarBlue);
 ```
 
-All sprites in the asset pack have a "preset", which is just a fancy `enum` that makes it easy for you as a user to select one of sprite image files. You could also specify the image filepath, relative to the `assets/sprite` directory, which you would do if you add your own images.  For example, the full filepath of the blue racing car is `assets/sprite/racing/car_blue.png`, so to create it by filepath you would do:
+All sprites in the asset pack have a "preset", which is just a fancy `enum` that makes it easy for you as a user to select one of sprite image files that are included in the default assets pack. You could also specify the image filepath, relative to the `assets/` directory, which you would do if you add your own images.  For example, the full filepath of the blue racing car is `assets/sprite/racing/car_blue.png`, so to create it by filepath you would do:
 
 ```rust,ignored
-let _ = engine.add_sprite("my_player", "racing/car_blue.png");
+let _ = engine.add_sprite("my_player", "sprite/racing/car_blue.png");
 ```
 
 `add_sprite` returns a mutable reference to a `Sprite` (`&mut Sprite`). Since it will emit a warning to silently ignore the reference, you should explicitly ignore it if you are not going to use it by doing `let _ = ...` as in the examples above. However, most of the time you will want to use the mutable reference to immediately adjust your sprite.

--- a/tutorial/src/60-sprite-placement.md
+++ b/tutorial/src/60-sprite-placement.md
@@ -8,15 +8,31 @@ There are four different fields you can use to position and size your sprite:
 
 ### Rotation
 
-`Sprite.rotation` is an `f32` representing the angle in radians from the positive X axis. In other words, a rotation of `0.0` is facing to the right, so custom images you want to use in Rusty Engine should also be "facing" to the right in their raw form (whatever "to the right" means is up to you). `2 * PI` brings you in a full circle, so `0.5 * PI` is "up", `PI` is "left", and `1.5 * PI` is "down". There are a bunch of helpful constants defined for cardinal directions if you don't want to remember the numerical value yourself.
+`Sprite.rotation` is an `f32` representing the angle in radians from the positive X axis. In other words, a rotation of `0.0` is facing to the right, so custom images you want to use in Rusty Engine should also be "facing" to the right in their raw form (whatever "to the right" means is up to you). `2 * PI` brings you in a full circle, so `0.5 * PI` is "up", `PI` is "left", and `1.5 * PI` is "down". There are a bunch of helpful constants defined for cardinal directions if you don't want to remember the numerical value yourself. These constants are all included in the prelude.
+
+```
+UP
+DOWN
+LEFT
+RIGHT
+
+NORTH
+NORTH_EAST
+EAST
+SOUTH_EAST
+SOUTH
+SOUTH_WEST
+WEST
+NORTH_WEST
+```
 
 ### Scale
 
-`Sprite.scale` is an `f32`. `1.0` means matching a pixel of the source image to a pixel on the screen. `2.0` makes the image twice as wide and tall, etc.
+`Sprite.scale` is an `f32`. `1.0` is the default, which means matching a pixel of the source image to a pixel on the screen. `2.0` makes the image twice as wide and tall, etc.
 
 ### Layer
 
-`Sprite.layer` is an `f32` that affects what sprite or text is "on top" of another sprite or text when they overlap. `0.0` is the default and "bottom" layer, and `999.0` is the "top" layer. The order of sprites or text on the same layer is random and unstable (can change frame to frame), so you should make sure that sprites and text that will overlap are on different layers. A good practice is to choose a few layers and assign them to constants. For example:
+`Sprite.layer` is an `f32` that affects what sprite or text is "on top" of another sprite or text when they overlap. `0.0` is the default layer and is on the "bottom", while `999.0` is the "top" layer. The order of sprites or text on the same layer is random and unstable (can change frame to frame), so you should make sure that sprites and text that will overlap are on different layers so they don't change their position unpredictably. A good practice is to choose a few layers and assign them to constants, and then don't let sprites on the same layer overlap. For example:
 
 ```rust,ignored
 const BACKGROUND_LAYER: f32 = 0.0;
@@ -50,7 +66,7 @@ NOTE: If you want to adjust your sprite smoothly, you will need to multiply it b
 
 ### Adjusting an existing sprite
 
-To adjust a sprite which already exists, you need to get a mutable reference to it.  This is where that "label" comes in.  The `Engine.sprites` field is a hash map of labels to sprites. You get a mutable reference to a sprite with the `HashMap::get_mut` method:
+To adjust a sprite which already exists, you need to get a mutable reference to it.  This is where that "label" comes in.  The `sprites` field on the `Engine` struct is a hash map of labels to sprites. You get a mutable reference to a sprite with the `HashMap::get_mut` method:
 
 
 ```rust,ignored
@@ -61,7 +77,7 @@ player_reference.rotation += TURN_SPEED_PER_SEC * engine.delta_f32;
 
 ### Deleting a sprite
 
-To delete a sprite, simply remove it from the `Engine.sprites` hash map.
+To delete a sprite, remove it from the `Engine.sprites` hash map.
 
 ```rust,ignored
 engine.sprites.remove("my_player");

--- a/tutorial/src/65-sprite-collider.md
+++ b/tutorial/src/65-sprite-collider.md
@@ -6,7 +6,7 @@ Rusty Engine has a basic system for detecting collisions between sprites. When t
 
 Your game logic should process collision events each frame. Collision events which you don't handle are discarded at the end of each frame. Collision events are accessed through the `Engine.collision_events` vector.
 
-Each `CollisionEvent` consists of a `CollisionState` (an enum of either `Begin` or `End`) and a `CollisionPair`, which is a tuple of the labels of the two sprites involved in the collision. It is up to you to figure out what to do with the information that a collision occurred.
+Each `CollisionEvent` consists of a `CollisionState` (an enum with `Begin` and `End` variants) and a `CollisionPair`, which is a tuple of the labels of the two sprites involved in the collision. It is up to you to figure out what to do with the information that a collision occurred.
 
 
 ```rust,ignored
@@ -26,21 +26,21 @@ for event in engine.collision_events.drain(..) {
 
 Colliders are convex polygons that are used to detect if a collision has occurred between two sprites. Colliders will be rendered as polygons with white lines on the screen if `Engine.show_colliders` is set to `true`.
 
-Colliders are stored in files with the same filename and path as the image file the sprite uses, but with a `.collider` extension. If a valid collider file exists, it will be loaded automatically. 
+Colliders are stored in the same directory as the images they are for, and the collider files use the same filename as the image file the sprite uses, but with a `.collider` extension. If a valid collider file exists, it will be loaded automatically. 
 
 ### Creating colliders
 
-All of the sprite presets in the game already have colliders, so you only have to set the `collision` field to true for sprite presets.
+All of the sprite presets in the game already have colliders, so you only have to set the `collision` field to `true` for sprite presets and you're ready to go.
 
 If you create a new sprite using your own image, and you want it to produce `CollisionEvent`s, then you need to create a collider for that sprite.
 
-Creating colliders from scratch is quite tedius, so there is an "example" program called `collider` that you can use to create a collider! To run `collider`, clone the [`rusty_engine`](https://github.com/CleanCut/rusty_engine/) repository, place your image file in the `assets` directory (let's call it `db.png`), and then run:
+Creating colliders from scratch is quite tedius, so there is an "example" program called `collider` that you can use to create a collider! To install and use `collider`, do the following:
 
 ```text
 # Install the collider example (you only need to do this once)
 $ cargo install rusty_engine --example collider
 
-# Inside your project, run the collider example
+# Inside your project, run the collider example and pass it the path to your image file.
 $ collider assets/db.png
 ```
 
@@ -48,4 +48,4 @@ Then follow the example's console instructions to create (or re-create) a collid
 
 <img width="1392" alt="Screen Shot 2021-12-26 at 10 45 40 PM" src="https://user-images.githubusercontent.com/5838512/147438683-c8af2db7-66dd-463c-a269-d03f37869496.png">
 
-Once you have a good collider created, copy (or move) both your image and `.collider` files to your own project, under the `assets/` directory somewhere, and then [add the sprite to your game](55-sprite-creation.md)
+Once you have created the collider, [add the sprite to your game](55-sprite-creation.md) and set the `collision` field to `true`!


### PR DESCRIPTION
I started upgrading the underlying version of Bevy from 0.8 a couple months ago and got distracted. Today I sat down and spent a few hours upgrading all the way to Bevy 0.12.

### Breaking changes

- `WindowDescriptor` has been renamed to `Window`
- You must new add `#[derive(Resource)]` above your `GameState` struct.
- It is no longer possible to use the unit type `()` instead of a `GameState` struct. Always create a `GameState` struct (it can be an empty struct with no fields).
- The `Timer` now takes a `TimerMode` enum variant instead of a `bool`. Use `TimerMode::Once` for a timer that runs once, or `TimerMode::Repeating` for a repeating timer.
- The following `KeyCode` variants have been renamed:
  - `LShift` -> `ShiftLeft`
  - `RShift` -> `ShiftRight`
  - `LAlt` -> `AltLeft`
  - `RAlt` -> `AltRight`
  - `LBracket` -> `BracketLeft`
  - `RBracket` -> `BracketRight`
  - `LControl` -> `ControlLeft`
  - `RControl` -> `ControlRight`
  - `LShift` -> `ShiftLeft`
  - `LWin` -> `SuperLeft`
  - `RWin` -> `SuperRight`


### Improved

- Update bevy from 0.8 to 0.12
- Update bevy_prototype_lyon from 0.6 to 0.10
- Update ron from 0.7 to 0.8
- Fixed some inconsistent parameter names in examples
- Some examples' audio was turned down lower
